### PR TITLE
fix: broken documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A RESTful API for managing your Postgres. Fetch tables, add roles, and run queri
 
 ## Usage
 
-Full documentation: https://supabase.github.io/pg-api/
+Full documentation: https://supabase.github.io/postgres-meta/
 
 ## Quickstart
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Broken link to documentation