### PR TITLE
fix(publications): disambiguate tables' schemas

### DIFF
--- a/src/lib/sql/publications.sql
+++ b/src/lib/sql/publications.sql
@@ -15,15 +15,22 @@ FROM
   LEFT JOIN LATERAL (
     SELECT
       COALESCE(
-        array_agg(c.relname :: text) filter (
-          WHERE
-            c.relname IS NOT NULL
+        array_agg(
+          json_build_object(
+            'id',
+            c.oid :: int8,
+            'name',
+            c.relname,
+            'schema',
+            nc.nspname
+          )
         ),
         '{}'
       ) AS tables
     FROM
       pg_catalog.pg_publication_rel AS pr
       JOIN pg_class AS c ON pr.prrelid = c.oid
+      join pg_namespace as nc on c.relnamespace = nc.oid
     WHERE
       pr.prpubid = p.oid
   ) AS pr ON 1 = 1


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`/publications`'s tables only have names, so we can't differentiate tables from different schemas.

## What is the new behavior?

Make `tables` a JSON object as per #97. (Breaking change)

## Additional context

Closes #97.
