### PR TITLE
feat(lib): add naive constraint definition

### DIFF
--- a/src/lib/PostgresMetaColumns.ts
+++ b/src/lib/PostgresMetaColumns.ts
@@ -89,7 +89,7 @@ export default class PostgresMetaColumns {
     is_primary_key = false,
     is_unique = false,
     comment,
-    constraint,
+    check,
   }: {
     table_id: number
     name: string
@@ -102,7 +102,7 @@ export default class PostgresMetaColumns {
     is_primary_key?: boolean
     is_unique?: boolean
     comment?: string
-    constraint?: string
+    check?: string
   }): Promise<PostgresMetaResult<PostgresColumn>> {
     const { data, error } = await this.metaTables.retrieve({ id: table_id })
     if (error) {
@@ -122,10 +122,7 @@ export default class PostgresMetaColumns {
     const isNullableClause = is_nullable ? 'NULL' : 'NOT NULL'
     const isPrimaryKeyClause = is_primary_key ? 'PRIMARY KEY' : ''
     const isUniqueClause = is_unique ? 'UNIQUE' : ''
-    const constraintSql =
-      constraint === undefined
-        ? ''
-        : constraint
+    const checkSql = check === undefined ? '' : `CHECK (${check})`
     const commentSql =
       comment === undefined
         ? ''
@@ -139,7 +136,7 @@ BEGIN;
     ${isNullableClause}
     ${isPrimaryKeyClause}
     ${isUniqueClause}
-    ${constraintSql};
+    ${checkSql};
   ${commentSql};
 COMMIT;`
     {

--- a/src/lib/PostgresMetaColumns.ts
+++ b/src/lib/PostgresMetaColumns.ts
@@ -89,6 +89,7 @@ export default class PostgresMetaColumns {
     is_primary_key = false,
     is_unique = false,
     comment,
+    constraint,
   }: {
     table_id: number
     name: string
@@ -101,6 +102,7 @@ export default class PostgresMetaColumns {
     is_primary_key?: boolean
     is_unique?: boolean
     comment?: string
+    constraint?: string
   }): Promise<PostgresMetaResult<PostgresColumn>> {
     const { data, error } = await this.metaTables.retrieve({ id: table_id })
     if (error) {
@@ -120,6 +122,10 @@ export default class PostgresMetaColumns {
     const isNullableClause = is_nullable ? 'NULL' : 'NOT NULL'
     const isPrimaryKeyClause = is_primary_key ? 'PRIMARY KEY' : ''
     const isUniqueClause = is_unique ? 'UNIQUE' : ''
+    const constraintSql =
+      constraint === undefined
+        ? ''
+        : constraint
     const commentSql =
       comment === undefined
         ? ''
@@ -132,7 +138,8 @@ BEGIN;
     ${isIdentityClause}
     ${isNullableClause}
     ${isPrimaryKeyClause}
-    ${isUniqueClause};
+    ${isUniqueClause}
+    ${constraintSql};
   ${commentSql};
 COMMIT;`
     {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -416,11 +416,11 @@ describe('/tables', async () => {
   })
   it('POST /columns with constraint definition', async () => {
     const { data: newTable } = await axios.post(`${URL}/tables`, { name: 'a' })
-    const { error } = await axios.post(`${URL}/columns`, {
+    await axios.post(`${URL}/columns`, {
       table_id: newTable.id,
       name: 'description',
       type: 'text',
-      constraint: "CHECK (description <> '')",
+      check: "description <> ''",
     })
 
     const { data: constraints } = await axios.post(

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -414,6 +414,21 @@ describe('/tables', async () => {
     await axios.delete(`${URL}/columns/${newTable.id}.1`)
     await axios.delete(`${URL}/tables/${newTable.id}`)
   })
+  it('POST /columns with constraint definition', async () => {
+    const { data: newTable } = await axios.post(`${URL}/tables`, { name: 'a' })
+    const { error } = await axios.post(`${URL}/columns`, {
+      table_id: newTable.id,
+      name: 'description',
+      type: 'text',
+      constraint: "CHECK (description <> '')",
+    })
+
+    // TODO: some way to check constraints?
+    assert.equal(error, undefined)
+
+    await axios.delete(`${URL}/columns/${newTable.id}.1`)
+    await axios.delete(`${URL}/tables/${newTable.id}`)
+  })
   it('PATCH /columns', async () => {
     const { data: newTable } = await axios.post(`${URL}/tables`, { name: 'foo bar' })
     await axios.post(`${URL}/columns`, {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -423,8 +423,18 @@ describe('/tables', async () => {
       constraint: "CHECK (description <> '')",
     })
 
-    // TODO: some way to check constraints?
-    assert.equal(error, undefined)
+    const { data: constraints } = await axios.post(
+      `${URL}/query`,
+      { query: `
+        SELECT pg_get_constraintdef((
+          SELECT c.oid
+          FROM   pg_constraint c
+          WHERE  c.conrelid = '${newTable.name}'::regclass
+        ));
+      ` }
+    )
+    assert.equal(constraints.length, 1)
+    assert.equal(constraints[0].pg_get_constraintdef, "CHECK ((description <> ''::text))")
 
     await axios.delete(`${URL}/columns/${newTable.id}.1`)
     await axios.delete(`${URL}/tables/${newTable.id}`)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows users to define a `constraint` when creating a column https://github.com/supabase/postgres-meta/issues/100. Technically a user could specify multiple constraints in the string, not sure if we'd want something more structured? e.g. an array.