### PR TITLE
fix(publications): handle table name w/ uppercase

### DIFF
--- a/src/lib/PostgresMetaPublications.ts
+++ b/src/lib/PostgresMetaPublications.ts
@@ -68,7 +68,7 @@ export default class PostgresMetaPublications {
     } else if (tables.length === 0) {
       tableClause = ''
     } else {
-      tableClause = `FOR TABLE ${tables.join(',')}`
+      tableClause = `FOR TABLE ${tables.map(ident).join(',')}`
     }
 
     let publishOps = []
@@ -138,7 +138,7 @@ CREATE PUBLICATION ${ident(name)} ${tableClause}
     } else if (old!.tables === null) {
       throw new Error('Tables cannot be added to or dropped from FOR ALL TABLES publications')
     } else if (tables.length > 0) {
-      tableSql = `ALTER PUBLICATION ${ident(old!.name)} SET TABLE ${tables.join(',')};`
+      tableSql = `ALTER PUBLICATION ${ident(old!.name)} SET TABLE ${tables.map(ident).join(',')};`
     } else if (old!.tables.length === 0) {
       tableSql = ''
     } else {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -716,6 +716,16 @@ describe('/publications with tables', () => {
     const stillExists = publications.some((x) => x.id === id)
     assert.equal(stillExists, false)
   })
+  it('/publications for tables with uppercase', async () => {
+    const { data: table } = await axios.post(`${URL}/tables`, { name: 'T' })
+    const { data: publication } = await axios.post(`${URL}/publications`, { name: 'pub', tables: ['T'] })
+    assert.equal(publication.name, 'pub')
+    const { data: alteredPublication } = await axios.patch(`${URL}/publications/${publication.id}`, { tables: ['T'] })
+    assert.equal(alteredPublication.name, 'pub')
+
+    await axios.delete(`${URL}/publications/${publication.id}`)
+    await axios.delete(`${URL}/tables/${table.id}`)
+  })
 })
 
 describe('/publications FOR ALL TABLES', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

In `/publications` POST & PATCH, table names with uppercase aren't escaped properly.

## What is the new behavior?

Handle it properly.

## Additional context

Fixes #106.
