### PR TITLE
Fix: remove double quotes from publications create and update

### DIFF
--- a/src/lib/PostgresMetaPublications.ts
+++ b/src/lib/PostgresMetaPublications.ts
@@ -68,7 +68,7 @@ export default class PostgresMetaPublications {
     } else if (tables.length === 0) {
       tableClause = ''
     } else {
-      tableClause = `FOR TABLE ${tables.map(ident).join(',')}`
+      tableClause = `FOR TABLE ${tables.map(ident).join(',').replace(/"/g, '')}`
     }
 
     let publishOps = []
@@ -138,7 +138,10 @@ CREATE PUBLICATION ${ident(name)} ${tableClause}
     } else if (old!.tables === null) {
       throw new Error('Tables cannot be added to or dropped from FOR ALL TABLES publications')
     } else if (tables.length > 0) {
-      tableSql = `ALTER PUBLICATION ${ident(old!.name)} SET TABLE ${tables.map(ident).join(',')};`
+      tableSql = `ALTER PUBLICATION ${ident(old!.name)} SET TABLE ${tables
+        .map(ident)
+        .join(',')
+        .replace(/"/g, '')};`
     } else if (old!.tables.length === 0) {
       tableSql = ''
     } else {

--- a/src/lib/PostgresMetaPublications.ts
+++ b/src/lib/PostgresMetaPublications.ts
@@ -68,7 +68,7 @@ export default class PostgresMetaPublications {
     } else if (tables.length === 0) {
       tableClause = ''
     } else {
-      tableClause = `FOR TABLE ${tables.map(ident).join(',').replace(/"/g, '')}`
+      tableClause = `FOR TABLE ${tables.join(',')}`
     }
 
     let publishOps = []
@@ -138,10 +138,7 @@ CREATE PUBLICATION ${ident(name)} ${tableClause}
     } else if (old!.tables === null) {
       throw new Error('Tables cannot be added to or dropped from FOR ALL TABLES publications')
     } else if (tables.length > 0) {
-      tableSql = `ALTER PUBLICATION ${ident(old!.name)} SET TABLE ${tables
-        .map(ident)
-        .join(',')
-        .replace(/"/g, '')};`
+      tableSql = `ALTER PUBLICATION ${ident(old!.name)} SET TABLE ${tables.join(',')};`
     } else if (old!.tables.length === 0) {
       tableSql = ''
     } else {

--- a/src/lib/PostgresMetaPublications.ts
+++ b/src/lib/PostgresMetaPublications.ts
@@ -68,7 +68,17 @@ export default class PostgresMetaPublications {
     } else if (tables.length === 0) {
       tableClause = ''
     } else {
-      tableClause = `FOR TABLE ${tables.join(',')}`
+      tableClause = `FOR TABLE ${tables
+        .map((t) => {
+          if (!t.includes('.')) {
+            return ident(t)
+          }
+
+          const [schema, ...rest] = t.split('.')
+          const table = rest.join('.')
+          return `${ident(schema)}.${ident(table)}`
+        })
+        .join(',')}`
     }
 
     let publishOps = []
@@ -138,7 +148,17 @@ CREATE PUBLICATION ${ident(name)} ${tableClause}
     } else if (old!.tables === null) {
       throw new Error('Tables cannot be added to or dropped from FOR ALL TABLES publications')
     } else if (tables.length > 0) {
-      tableSql = `ALTER PUBLICATION ${ident(old!.name)} SET TABLE ${tables.join(',')};`
+      tableSql = `ALTER PUBLICATION ${ident(old!.name)} SET TABLE ${tables
+        .map((t) => {
+          if (!t.includes('.')) {
+            return ident(t)
+          }
+
+          const [schema, ...rest] = t.split('.')
+          const table = rest.join('.')
+          return `${ident(schema)}.${ident(table)}`
+        })
+        .join(',')};`
     } else if (old!.tables.length === 0) {
       tableSql = ''
     } else {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Related issue: https://github.com/supabase/supabase/issues/2123

Getting error: `"relation \"public.test\" does not exist"` (example error) b/c of the double quotes.

## What is the new behavior?

Double quotes are removed and I'm able to create/update publications

Feel free to include screenshots if it includes visual changes.