### PR TITLE
fix(functions): include argument_types retrieving function query

### DIFF
--- a/src/lib/sql/triggers.sql
+++ b/src/lib/sql/triggers.sql
@@ -42,7 +42,6 @@ GROUP BY
   is_t.event_object_schema,
   is_t.action_condition,
   is_t.action_orientation,
-  is_t.action_statement,
   is_t.action_timing,
   pg_p.proname,
   pg_n.nspname

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -161,7 +161,7 @@ describe('/functions', () => {
     id: null,
     name: 'test_func',
     schema: 'public',
-    params: ['integer', 'integer'],
+    args: ['integer', 'integer'],
     definition: 'select $1 + $2',
     rettype: 'integer',
     language: 'sql',
@@ -176,7 +176,7 @@ describe('/functions', () => {
   })
   after(async () => {
     await axios.post(`${URL}/query`, {
-      query: `DROP SCHEMA test_schema;`,
+      query: `DROP SCHEMA IF EXISTS test_schema;`,
     })
   })
   it('GET', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

retrieve function returns multiple records due to overloaded function names.

## What is the new behavior?

retrieve function returns single record despite overloaded function names.

## Additional context

@i-pip creating this PR as it was out of scope for https://github.com/supabase/postgres-meta/pull/118.
