### PR TITLE
feat: add additional function create options

### DIFF
--- a/src/lib/sql/functions.sql
+++ b/src/lib/sql/functions.sql
@@ -8,9 +8,34 @@ SELECT
     ELSE pg_get_functiondef(p.oid)
   END AS definition,
   pg_get_function_arguments(p.oid) AS argument_types,
-  t.typname AS return_type
+  t.typname AS return_type,
+  CASE
+    WHEN p.provolatile = 'i' THEN 'IMMUTABLE'
+    WHEN p.provolatile = 's' THEN 'STABLE'
+    WHEN p.provolatile = 'v' THEN 'VOLATILE'
+  END AS behavior,
+  p.prosecdef AS security_definer,
+  JSON_OBJECT_AGG(p_config.param, p_config.values)
+    FILTER (WHERE p_config.param IS NOT NULL) AS config_params
 FROM
   pg_proc p
   LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
   LEFT JOIN pg_language l ON p.prolang = l.oid
   LEFT JOIN pg_type t ON t.oid = p.prorettype
+  LEFT JOIN (
+    SELECT
+	    oid as id,
+	    (string_to_array(unnest(proconfig), '='))[1] AS param,
+   	  string_to_array((string_to_array(unnest(proconfig), '='))[2], ', ') AS values
+	  FROM
+	    pg_proc
+	) p_config ON p_config.id = p.oid
+GROUP BY
+  p.oid,
+  n.nspname,
+  p.proname,
+  l.lanname,
+  p.prosrc,
+  t.typname,
+  p.provolatile,
+  p.prosecdef

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,13 @@ const postgresFunctionSchema = Type.Object({
   definition: Type.String(),
   argument_types: Type.String(),
   return_type: Type.String(),
+  behavior: Type.Union([
+    Type.Literal('IMMUTABLE'),
+    Type.Literal('STABLE'),
+    Type.Literal('VOLATILE'),
+  ]),
+  security_definer: Type.Boolean(),
+  config_params: Type.Union([Type.Dict(Type.Array(Type.String())), Type.Null()]),
 })
 export type PostgresFunction = Static<typeof postgresFunctionSchema>
 

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -165,6 +165,9 @@ describe('/functions', () => {
     definition: 'select $1 + $2',
     rettype: 'integer',
     language: 'sql',
+    behavior: 'STABLE',
+    security_definer: true,
+    config_params: { search_path: ['hooks', 'auth'], role: ['postgres'] },
   }
   before(async () => {
     await axios.post(`${URL}/query`, {
@@ -212,6 +215,9 @@ describe('/functions', () => {
     assert.strictEqual(newFunc.schema, 'public')
     assert.strictEqual(newFunc.language, 'sql')
     assert.strictEqual(newFunc.return_type, 'int4')
+    assert.strictEqual(newFunc.behavior, 'STABLE')
+    assert.strictEqual(newFunc.security_definer, true)
+    assert.deepStrictEqual(newFunc.config_params, { search_path: ['hooks', 'auth'], role: ['postgres'] })
     func.id = newFunc.id
   })
   it('PATCH', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Add the following options when creating functions:

- [X] IMMUTABLE / STABLE / VOLATILE
- [X] SECURITY INVOKER / SECURITY DEFINER
- [X] SET configuration_parameter { TO value | = value | FROM CURRENT }
