### PR TITLE
chore: update function option rettype to return_type

### DIFF
--- a/src/lib/PostgresMetaFunctions.ts
+++ b/src/lib/PostgresMetaFunctions.ts
@@ -80,7 +80,7 @@ export default class PostgresMetaFunctions {
     schema = 'public',
     args = [],
     definition,
-    rettype = 'void',
+    return_type = 'void',
     language = 'sql',
     behavior = 'VOLATILE',
     security_definer = false,
@@ -90,7 +90,7 @@ export default class PostgresMetaFunctions {
     schema?: string
     args?: string[]
     definition: string
-    rettype?: string
+    return_type?: string
     language?: string
     behavior?: 'IMMUTABLE' | 'STABLE' | 'VOLATILE'
     security_definer?: boolean
@@ -98,7 +98,7 @@ export default class PostgresMetaFunctions {
   }): Promise<PostgresMetaResult<PostgresFunction>> {
     const sql = `
       CREATE FUNCTION ${ident(schema)}.${ident(name)}(${args.join(', ')})
-      RETURNS ${rettype}
+      RETURNS ${return_type}
       AS ${literal(definition)}
       LANGUAGE ${language}
       ${behavior}

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -163,7 +163,7 @@ describe('/functions', () => {
     schema: 'public',
     args: ['integer', 'integer'],
     definition: 'select $1 + $2',
-    rettype: 'integer',
+    return_type: 'integer',
     language: 'sql',
     behavior: 'STABLE',
     security_definer: true,


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

function create `rettype` option

## What is the new behavior?

function create `return_type` option

## Additional context

Related issue: https://github.com/supabase/postgres-meta/issues/132