### PR TITLE
feat: add table_id to trigger return

### DIFF
--- a/src/lib/PostgresMetaTriggers.ts
+++ b/src/lib/PostgresMetaTriggers.ts
@@ -130,7 +130,9 @@ export default class PostgresMetaTriggers {
     const triggerCondition = condition ? `WHEN (${condition})` : ''
     const functionArgs = `${function_args?.map(literal).join(',') ?? ''}`
 
-    const sql = `CREATE TRIGGER ${ident(name)} ${activation} ${triggerEvents} ON ${qualifiedTableName} ${triggerOrientation} ${triggerCondition} EXECUTE FUNCTION ${qualifiedFunctionName}(${functionArgs});`
+    const sql = `CREATE TRIGGER ${ident(
+      name
+    )} ${activation} ${triggerEvents} ON ${qualifiedTableName} ${triggerOrientation} ${triggerCondition} EXECUTE FUNCTION ${qualifiedFunctionName}(${functionArgs});`
 
     const { error } = await this.query(sql)
 

--- a/src/lib/sql/triggers.sql
+++ b/src/lib/sql/triggers.sql
@@ -1,5 +1,6 @@
 SELECT
   pg_t.oid AS id,
+  pg_t.tgrelid AS table_id,
   CASE
     WHEN pg_t.tgenabled = 'D' THEN 'DISABLED'
     WHEN pg_t.tgenabled = 'O' THEN 'ORIGIN'
@@ -34,6 +35,7 @@ JOIN pg_namespace AS pg_n
 ON pg_p.pronamespace = pg_n.oid
 GROUP BY
   pg_t.oid,
+  pg_t.tgrelid,
   pg_t.tgenabled,
   pg_t.tgargs,
   pg_t.tgnargs,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -234,6 +234,7 @@ export type PostgresTable = Static<typeof postgresTableSchema>
 
 export const postgresTriggerSchema = Type.Object({
   id: Type.Integer(),
+  table_id: Type.Integer(),
   enabled_mode: Type.Union([
     Type.Literal('ORIGIN'),
     Type.Literal('REPLICA'),

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -933,6 +933,7 @@ describe('/triggers', () => {
     const { data: triggerRecord } = await axios.post(`${URL}/triggers`, trigger)
 
     assert.strictEqual(typeof triggerRecord.id, 'number')
+    assert.strictEqual(typeof triggerRecord.table_id, 'number')
     assert.strictEqual(triggerRecord.enabled_mode, 'ORIGIN')
     assert.strictEqual(triggerRecord.name, 'test_trigger')
     assert.strictEqual(triggerRecord.table, 'users_audit')


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

add tg_rel_id (trigger table id) in trigger return
