### PR TITLE
feat: change function config param value to string

### DIFF
--- a/src/lib/PostgresMetaFunctions.ts
+++ b/src/lib/PostgresMetaFunctions.ts
@@ -94,7 +94,7 @@ export default class PostgresMetaFunctions {
     language?: string
     behavior?: 'IMMUTABLE' | 'STABLE' | 'VOLATILE'
     security_definer?: boolean
-    config_params: { [key: string]: string[] }
+    config_params: { [key: string]: string }
   }): Promise<PostgresMetaResult<PostgresFunction>> {
     const sql = `
       CREATE FUNCTION ${ident(schema)}.${ident(name)}(${args.join(', ')})
@@ -105,10 +105,8 @@ export default class PostgresMetaFunctions {
       ${security_definer ? 'SECURITY DEFINER' : 'SECURITY INVOKER'}
       ${Object.entries(config_params)
         .map(
-          ([param, values]) =>
-            `SET ${param} ${
-              values[0] === 'FROM CURRENT' ? 'FROM CURRENT' : 'TO ' + values.map(ident).join(',')
-            }`
+          ([param, value]) =>
+            `SET ${param} ${value[0] === 'FROM CURRENT' ? 'FROM CURRENT' : 'TO ' + value}`
         )
         .join('\n')}
       RETURNS NULL ON NULL INPUT;

--- a/src/lib/sql/functions.sql
+++ b/src/lib/sql/functions.sql
@@ -15,7 +15,7 @@ SELECT
     WHEN p.provolatile = 'v' THEN 'VOLATILE'
   END AS behavior,
   p.prosecdef AS security_definer,
-  JSON_OBJECT_AGG(p_config.param, p_config.values)
+  JSON_OBJECT_AGG(p_config.param, p_config.value)
     FILTER (WHERE p_config.param IS NOT NULL) AS config_params
 FROM
   pg_proc p
@@ -26,7 +26,7 @@ FROM
     SELECT
 	    oid as id,
 	    (string_to_array(unnest(proconfig), '='))[1] AS param,
-   	  string_to_array((string_to_array(unnest(proconfig), '='))[2], ', ') AS values
+   	  (string_to_array(unnest(proconfig), '='))[2] AS value
 	  FROM
 	    pg_proc
 	) p_config ON p_config.id = p.oid

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -84,7 +84,7 @@ const postgresFunctionSchema = Type.Object({
     Type.Literal('VOLATILE'),
   ]),
   security_definer: Type.Boolean(),
-  config_params: Type.Union([Type.Dict(Type.Array(Type.String())), Type.Null()]),
+  config_params: Type.Union([Type.Dict(Type.String()), Type.Null()]),
 })
 export type PostgresFunction = Static<typeof postgresFunctionSchema>
 

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -167,7 +167,7 @@ describe('/functions', () => {
     language: 'sql',
     behavior: 'STABLE',
     security_definer: true,
-    config_params: { search_path: ['hooks', 'auth'], role: ['postgres'] },
+    config_params: { search_path: 'hooks, auth', role: 'postgres' },
   }
   before(async () => {
     await axios.post(`${URL}/query`, {
@@ -217,7 +217,7 @@ describe('/functions', () => {
     assert.strictEqual(newFunc.return_type, 'int4')
     assert.strictEqual(newFunc.behavior, 'STABLE')
     assert.strictEqual(newFunc.security_definer, true)
-    assert.deepStrictEqual(newFunc.config_params, { search_path: ['hooks', 'auth'], role: ['postgres'] })
+    assert.deepStrictEqual(newFunc.config_params, { search_path: 'hooks, auth', role: 'postgres' })
     func.id = newFunc.id
   })
   it('PATCH', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

when creating a function, `config_params` is passed in as object where both param and value are strings.