### PR TITLE
fix: create functions with alias data types

### DIFF
--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -161,8 +161,8 @@ describe('/functions', () => {
     id: null,
     name: 'test_func',
     schema: 'public',
-    args: ['integer', 'integer'],
-    definition: 'select $1 + $2',
+    args: ['a int2', 'b int2'],
+    definition: 'select a + b',
     return_type: 'integer',
     language: 'sql',
     behavior: 'STABLE',
@@ -213,6 +213,7 @@ describe('/functions', () => {
     const { data: newFunc } = await axios.post(`${URL}/functions`, func)
     assert.strictEqual(newFunc.name, 'test_func')
     assert.strictEqual(newFunc.schema, 'public')
+    assert.strictEqual(newFunc.argument_types, 'a smallint, b smallint')
     assert.strictEqual(newFunc.language, 'sql')
     assert.strictEqual(newFunc.return_type, 'int4')
     assert.strictEqual(newFunc.behavior, 'STABLE')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

create function, but fails to fetch created function, with function args being alias data types like `int2, int4, etc.`

## What is the new behavior?

create function, then successfully fetch created function, with function args being alias data types like `int2, int4, etc.`

## Additional context

test example:

```
{
   "name":"add",
   "schema":"public",
   "definition":"SELECT a + b;",
   "rettype":"integer",
   "language":"sql",
   "behavior":"STABLE",
   "args":["a int4","b int4"]
}
```
