### PR TITLE
refactor: convert FunctionInputs to PostgresFunctionCreate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.16.7",
+        "@sinclair/typebox": "^0.19.2",
         "pg": "^7.0.0",
         "pg-format": "^1.0.4"
       },
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.16.7.tgz",
-      "integrity": "sha512-d12AkLZJXD30hXBhJSgf33RqGO0NMHIDzsQPYfp6WGoaSuMnSGIUanII2OUbeZFnD/j3Nbl2zifgO2+5tPClCQ=="
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.19.2.tgz",
+      "integrity": "sha512-0U/RVPZQw1QxhrbKV0o281ZWI1Ve3osJnyEYnwOp3slydIQHyXumbJANJeNv9BqABDiHWlmzsxSVopPHMvt3Aw=="
     },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
@@ -6749,9 +6749,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.16.7.tgz",
-      "integrity": "sha512-d12AkLZJXD30hXBhJSgf33RqGO0NMHIDzsQPYfp6WGoaSuMnSGIUanII2OUbeZFnD/j3Nbl2zifgO2+5tPClCQ=="
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.19.2.tgz",
+      "integrity": "sha512-0U/RVPZQw1QxhrbKV0o281ZWI1Ve3osJnyEYnwOp3slydIQHyXumbJANJeNv9BqABDiHWlmzsxSVopPHMvt3Aw=="
     },
     "@types/color-name": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "run-s build:server && node -r esm ./node_modules/.bin/mocha 'test/**/*.js' --recursive"
   },
   "dependencies": {
-    "@sinclair/typebox": "^0.16.7",
+    "@sinclair/typebox": "^0.19.2",
     "pg": "^7.0.0",
     "pg-format": "^1.0.4"
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -85,9 +85,24 @@ const postgresFunctionSchema = Type.Object({
     Type.Literal('VOLATILE'),
   ]),
   security_definer: Type.Boolean(),
-  config_params: Type.Union([Type.Dict(Type.String()), Type.Null()]),
+  config_params: Type.Union([Type.Record(Type.String(), Type.String()), Type.Null()]),
 })
 export type PostgresFunction = Static<typeof postgresFunctionSchema>
+
+export const postgresFunctionCreateFunction = Type.Object({
+  name: Type.String(),
+  definition: Type.String(),
+  args: Type.Optional(Type.Array(Type.String())),
+  behavior: Type.Optional(
+    Type.Union([Type.Literal('IMMUTABLE'), Type.Literal('STABLE'), Type.Literal('VOLATILE')])
+  ),
+  config_params: Type.Optional(Type.Record(Type.String(), Type.String())),
+  schema: Type.Optional(Type.String()),
+  language: Type.Optional(Type.String()),
+  return_type: Type.Optional(Type.String()),
+  security_definer: Type.Optional(Type.Boolean()),
+})
+export type PostgresFunctionCreate = Static<typeof postgresFunctionCreateFunction>
 
 export const postgresGrantSchema = Type.Object({
   table_id: Type.Integer(),


### PR DESCRIPTION
## What kind of change does this PR introduce?

refactor

## What is the new behavior?

Creating and updating functions will use the `PostgresFunctionCreate` type.

## Additional context

Refactor based on feedback: https://github.com/supabase/postgres-meta/pull/137#issuecomment-886453986
