### PR TITLE
fix: update and delete function based on its identity args

### DIFF
--- a/src/lib/sql/functions.sql
+++ b/src/lib/sql/functions.sql
@@ -12,6 +12,7 @@ SELECT
     ELSE pg_get_functiondef(p.oid)
   END AS complete_statement,
   pg_get_function_arguments(p.oid) AS argument_types,
+  pg_get_function_identity_arguments(p.oid) AS identity_argument_types,
   t.typname AS return_type,
   CASE
     WHEN p.provolatile = 'i' THEN 'IMMUTABLE'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,7 @@ const postgresFunctionSchema = Type.Object({
   definition: Type.String(),
   complete_statement: Type.String(),
   argument_types: Type.String(),
+  identity_argument_types: Type.String(),
   return_type: Type.String(),
   behavior: Type.Union([
     Type.Literal('IMMUTABLE'),

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -214,6 +214,7 @@ describe('/functions', () => {
     assert.strictEqual(newFunc.name, 'test_func')
     assert.strictEqual(newFunc.schema, 'public')
     assert.strictEqual(newFunc.argument_types, 'a smallint, b smallint')
+    assert.strictEqual(newFunc.identity_argument_types, 'a smallint, b smallint')
     assert.strictEqual(newFunc.language, 'sql')
     assert.strictEqual(newFunc.definition, 'select a + b')
     assert.strictEqual(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Unable to update or delete functions with `argmode`s and defaults.

## What is the new behavior?

Successfully update or delete functions with `argmode`s and defaults.

## Additional context

Related issue:

https://github.com/supabase/supabase/issues/2777
