### PR TITLE
fix(server): Cannot read property 'accept-version' of undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "build:server": "tsc -p tsconfig.server.json && cpy 'src/lib/sql/*.sql' bin/src/lib/sql",
     "docs:export": "PG_META_EXPORT_DOCS=true ts-node-dev src/server/app.ts",
     "start": "NODE_ENV=production node bin/src/server/app.js",
-    "dev": "run-s clean && NODE_ENV=development ts-node-dev src/server/app.ts | pino-pretty --colorize",
+    "dev": "run-s db:clean db:run && NODE_ENV=development ts-node-dev src/server/app.ts | pino-pretty --colorize",
     "pkg": "run-s clean build:server && pkg --out-path bin .pkg.config.json",
-    "test": "run-s test:db test:run test:clean",
-    "test:clean": "cd test/db && docker-compose down",
-    "test:db": "cd test/db && docker-compose up --detach",
+    "test": "run-s db:clean db:run test:run db:clean",
+    "db:clean": "cd test/db && docker-compose down",
+    "db:run": "cd test/db && docker-compose up --detach",
     "test:run": "jest --runInBand"
   },
   "engines": {

--- a/src/server/routes/columns.ts
+++ b/src/server/routes/columns.ts
@@ -79,7 +79,7 @@ export default async (fastify: FastifyInstance) => {
     const { data, error } = await pgMeta.columns.update(request.params.id, request.body)
     await pgMeta.end()
     if (error) {
-      request.log.error({ error, req: request.body })
+      request.log.error(JSON.stringify({ error, req: request.body }))
       reply.code(400)
       if (error.message.startsWith('Cannot find')) reply.code(404)
       return { error: error.message }

--- a/src/server/routes/schemas.ts
+++ b/src/server/routes/schemas.ts
@@ -162,7 +162,7 @@ export default async (fastify: FastifyInstance) => {
       const { data, error } = await pgMeta.schemas.update(id, request.body)
       await pgMeta.end()
       if (error) {
-        request.log.error({ error, req: request.body })
+        request.log.error(JSON.stringify({ error, req: request.body }))
         reply.code(400)
         if (error.message.startsWith('Cannot find')) reply.code(404)
         return { error: error.message }
@@ -213,7 +213,7 @@ export default async (fastify: FastifyInstance) => {
       const { data, error } = await pgMeta.schemas.remove(id, { cascade })
       await pgMeta.end()
       if (error) {
-        request.log.error({ error, req: request.body })
+        request.log.error(JSON.stringify({ error, req: request.body }))
         reply.code(400)
         if (error.message.startsWith('Cannot find')) reply.code(404)
         return { error: error.message }

--- a/src/server/routes/tables.ts
+++ b/src/server/routes/tables.ts
@@ -37,7 +37,7 @@ export default async (fastify: FastifyInstance) => {
     const { data, error } = await pgMeta.tables.retrieve({ id })
     await pgMeta.end()
     if (error) {
-      request.log.error({ error, req: request.body })
+      request.log.error(JSON.stringify({ error, req: request.body }))
       reply.code(404)
       return { error: error.message }
     }

--- a/src/server/routes/triggers.ts
+++ b/src/server/routes/triggers.ts
@@ -33,7 +33,7 @@ export default async (fastify: FastifyInstance) => {
     const { data, error } = await pgMeta.triggers.retrieve({ id })
     await pgMeta.end()
     if (error) {
-      request.log.error({ error, req: request.body })
+      request.log.error(JSON.stringify({ error, req: request.body }))
       reply.code(404)
       return { error: error.message }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Some failing requests are returning cryptic `Cannot read property 'accept-version' of undefined` error.

## What is the new behavior?

Sayonara cryptic errors. Responses should now provide the *actual* errors.

## Additional context

Closes #144.
Related: https://github.com/supabase/supabase/issues/2404#issuecomment-913153702