### PR TITLE
fix: update existing function query

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ None. Please don't use this as a standalone server. This should be used behind a
 
 ## Developers
 
-1. Start the database using `docker-compose up`
+1. Start the database using `docker-compose -f test/db/docker-compose.yml up`
 2. Run `npm run dev`
 3. Run `npm test` while you work
 

--- a/src/lib/PostgresMetaFunctions.ts
+++ b/src/lib/PostgresMetaFunctions.ts
@@ -168,7 +168,9 @@ export default class PostgresMetaFunctions {
           IF (
             SELECT id
             FROM (${functionsSql}) AS f
-            WHERE f.identity_argument_types = ${literal(identityArgs)}
+            WHERE f.schema = ${literal(currentFunc!.schema)}
+            AND f.name = ${literal(currentFunc!.name)}
+            AND f.identity_argument_types = ${literal(identityArgs)}
           ) != ${id} THEN
             RAISE EXCEPTION 'Cannot find function "${currentFunc!.schema}"."${
       currentFunc!.name


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Attempting to select existing function returns all functions with the same identity_argument_types.

## What is the new behavior?

Selecting existing function returns a single function based on its schema, name, and identity_argument_types.

## Additional context

Related issue:  https://github.com/supabase/supabase/issues/3281