### PR TITLE
fix: obscure policies CTE bug

### DIFF
--- a/src/lib/PostgresMetaRoles.ts
+++ b/src/lib/PostgresMetaRoles.ts
@@ -35,7 +35,7 @@ WITH roles AS (${
   })
 SELECT
   *,
-  ${coalesceRowsToArray('grants', 'SELECT * FROM grants WHERE grants.grantee = roles.name')}
+  ${coalesceRowsToArray('grants', 'grants.grantee = roles.name')}
 FROM
   roles`
     if (limit) {

--- a/src/lib/PostgresMetaTables.ts
+++ b/src/lib/PostgresMetaTables.ts
@@ -211,21 +211,13 @@ WITH tables AS (${tablesSql}),
   relationships AS (${relationshipsSql})
 SELECT
   *,
-  ${coalesceRowsToArray('columns', 'SELECT * FROM columns WHERE columns.table_id = tables.id')},
-  ${coalesceRowsToArray('grants', 'SELECT * FROM grants WHERE grants.table_id = tables.id')},
-  ${coalesceRowsToArray('policies', 'SELECT * FROM policies WHERE policies.table_id = tables.id')},
-  ${coalesceRowsToArray(
-    'primary_keys',
-    'SELECT * FROM primary_keys WHERE primary_keys.table_id = tables.id'
-  )},
+  ${coalesceRowsToArray('columns', 'columns.table_id = tables.id')},
+  ${coalesceRowsToArray('grants', 'grants.table_id = tables.id')},
+  ${coalesceRowsToArray('policies', 'policies.table_id = tables.id')},
+  ${coalesceRowsToArray('primary_keys', 'primary_keys.table_id = tables.id')},
   ${coalesceRowsToArray(
     'relationships',
-    `SELECT
-       *
-     FROM
-       relationships
-     WHERE
-       (relationships.source_schema = tables.schema AND relationships.source_table_name = tables.name)
+    `(relationships.source_schema = tables.schema AND relationships.source_table_name = tables.name)
        OR (relationships.target_table_schema = tables.schema AND relationships.target_table_name = tables.name)`
   )}
 FROM tables`

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -11,16 +11,3 @@ COALESCE(
   '[]'
 ) AS ${source}`
 }
-
-/**
- * Transforms an array of SQL strings into a transaction
- */
-export const toTransaction = (statements: string[]) => {
-  let cleansed = statements.map((x) => {
-    let sql = x.trim()
-    if (sql.length > 0 && x.slice(-1) !== ';') sql += ';'
-    return sql
-  })
-  const allStatements = cleansed.join('')
-  return `BEGIN; ${allStatements} COMMIT;`
-}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,13 +1,12 @@
-export const coalesceRowsToArray = (source: string, joinQuery: string) => {
-  // Note that array_to_json(array_agg(row_to_json())) seems to perform better than json_agg
+export const coalesceRowsToArray = (source: string, filter: string) => {
   return `
 COALESCE(
   (
     SELECT
-      array_to_json(array_agg(row_to_json(${source})))
+      array_agg(row_to_json(${source})) FILTER (WHERE ${filter})
     FROM
-      ( ${joinQuery} ) ${source}
+      ${source}
   ),
-  '[]'
+  '{}'
 ) AS ${source}`
 }


### PR DESCRIPTION
This SQL adapted from pg-meta doesn't do what it says on the tin:
```postgresql
WITH tables AS (
  SELECT
    c.oid :: int8 AS id,
    c.relname AS name,
    c.relnamespace :: regnamespace :: text AS schema
  FROM
    pg_class c
  WHERE
    c.relkind = 'r'
),
policies AS (
  SELECT
    pol.oid :: int8 AS id,
    pol.polname AS name,
    c.oid :: int8 AS table_id
  FROM
    pg_policy pol
    JOIN pg_class c ON c.oid = pol.polrelid
)
SELECT
  *,
  COALESCE(
    (
      SELECT
        array_to_json(array_agg(row_to_json(policies)))
      FROM
        (
          SELECT
            *
          FROM
            policies
          WHERE
            policies.table_id = tables.id
        ) policies
    ),
    '[]'
  ) AS policies
FROM
  tables
WHERE
  tables.schema = 'public';
```
Instead you need to do:
```postgresql
WITH tables AS (
  SELECT
    c.oid :: int8 AS id,
    c.relname AS name,
    c.relnamespace :: regnamespace :: text AS schema
  FROM
    pg_class c
  WHERE
    c.relkind = 'r'
),
policies AS (
  SELECT
    pol.oid :: int8 AS id,
    pol.polname AS name,
    c.oid :: int8 AS table_id
  FROM
    pg_policy pol
    JOIN pg_class c ON c.oid = pol.polrelid
)
SELECT
  *,
  COALESCE(
    (
      SELECT
        json_agg(row_to_json(policies)) FILTER (
          WHERE
            table_id = tables.id
        )
      FROM
        policies
    ),
    '[]'
  ) AS policies
FROM
  tables
WHERE
  tables.schema = 'public';
```
Haven't checked the query planner, so not sure why the original one doesn't work. But it works for now so...