### PR TITLE
chore: cleaner logging output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "pg": "^8.7.1",
         "pg-format": "^1.0.4",
         "pgsql-parser": "^13.1.11",
+        "pino": "^7.6.3",
         "prettier": "^2.4.1",
         "prettier-plugin-sql": "^0.4.0",
         "sql-formatter": "^4.0.2"
@@ -23,6 +24,7 @@
         "@types/node": "^14.0.13",
         "@types/pg": "^7.14.3",
         "@types/pg-format": "^1.0.1",
+        "@types/pino": "^7.0.5",
         "cpy-cli": "^3.1.1",
         "crypto-js": "^4.0.0",
         "fastify": "^3.14.0",
@@ -1345,6 +1347,16 @@
       "integrity": "sha512-D3MEO6u3BObw3G4Xewjdx05MF5v/fiog78CedtrXe8BhONM8GvUz2dPfLWtI0BPRBoRd6anPHXe+sbrPReZouQ==",
       "dev": true
     },
+    "node_modules/@types/pino": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-7.0.5.tgz",
+      "integrity": "sha512-wKoab31pknvILkxAF8ss+v9iNyhw5Iu/0jLtRkUD74cNfOOLJNnqfFKAv0r7wVaTQxRZtWrMpGfShwwBjOcgcg==",
+      "deprecated": "This is a stub types definition. pino provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "pino": "*"
+      }
+    },
     "node_modules/@types/prettier": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
@@ -1800,7 +1812,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3089,6 +3100,17 @@
       "resolved": "https://registry.npmjs.org/dotty/-/dotty-0.1.0.tgz",
       "integrity": "sha512-VJzcXJZEckXowvj6yGJC2JH66DLEEm1d1QOB0hik1EvlbUpULvcYt411JeFuy8rNC96FG8V2N7pMkyjvK8LYwQ=="
     },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "node_modules/dynamic-dedupe": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
@@ -3168,7 +3190,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -3679,7 +3700,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
       "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3768,6 +3788,40 @@
       "resolved": "https://registry.npmjs.org/fastify-warning/-/fastify-warning-0.2.0.tgz",
       "integrity": "sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==",
       "dev": true
+    },
+    "node_modules/fastify/node_modules/pino": {
+      "version": "6.13.4",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.4.tgz",
+      "integrity": "sha512-g4tHSISmQJYUEKEMVdaZ+ZokWwFnTwZL5JPn+lnBVZ1BuBbrSchrXwQINknkM5+Q4fF6U9NjiI8PWwwMDHt9zA==",
+      "dev": true,
+      "dependencies": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.8",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "sonic-boom": "^1.0.2"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/fastify/node_modules/pino-std-serializers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
+      "dev": true
+    },
+    "node_modules/fastify/node_modules/sonic-boom": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+      "dev": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
+      }
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -7240,6 +7294,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -7711,21 +7770,40 @@
       }
     },
     "node_modules/pino": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
-      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
-      "dev": true,
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.6.3.tgz",
+      "integrity": "sha512-TCUDiN0QmzruJ5UE4mIFkTcfCSROV7IVRp5SEUH77UnjDHbeoFntj9jQexvYZhCHp1yhjYCH6vZ8rV85L04KaA==",
       "dependencies": {
         "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.8",
-        "fastify-warning": "^0.2.0",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
         "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.13.0"
       },
       "bin": {
         "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dependencies": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/pino-pretty": {
@@ -7752,10 +7830,9 @@
       }
     },
     "node_modules/pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "node_modules/pirates": {
       "version": "4.0.4",
@@ -8342,6 +8419,11 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -8451,8 +8533,7 @@
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-      "dev": true
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -8607,6 +8688,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redent": {
@@ -8908,6 +8997,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -9377,13 +9474,11 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-      "dev": true,
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.6.0.tgz",
+      "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
       "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -9685,6 +9780,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -9930,6 +10030,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.13.0.tgz",
+      "integrity": "sha512-kTMZeX4Dzlb1zZ00/01aerGaTw2i8NE4sWF0TvF1uXewRhCiUjCvatQkvxIvFqauWG2ADFS2Wpd3qBeYL9i3dg==",
+      "dependencies": {
+        "real-require": "^0.1.0"
       }
     },
     "node_modules/throat": {
@@ -12185,6 +12293,15 @@
       "integrity": "sha512-D3MEO6u3BObw3G4Xewjdx05MF5v/fiog78CedtrXe8BhONM8GvUz2dPfLWtI0BPRBoRd6anPHXe+sbrPReZouQ==",
       "dev": true
     },
+    "@types/pino": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-7.0.5.tgz",
+      "integrity": "sha512-wKoab31pknvILkxAF8ss+v9iNyhw5Iu/0jLtRkUD74cNfOOLJNnqfFKAv0r7wVaTQxRZtWrMpGfShwwBjOcgcg==",
+      "dev": true,
+      "requires": {
+        "pino": "*"
+      }
+    },
     "@types/prettier": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
@@ -12537,8 +12654,7 @@
     "atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "dev": true
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "avvio": {
       "version": "7.2.2",
@@ -13533,6 +13649,17 @@
       "resolved": "https://registry.npmjs.org/dotty/-/dotty-0.1.0.tgz",
       "integrity": "sha512-VJzcXJZEckXowvj6yGJC2JH66DLEEm1d1QOB0hik1EvlbUpULvcYt411JeFuy8rNC96FG8V2N7pMkyjvK8LYwQ=="
     },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "dynamic-dedupe": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
@@ -13600,7 +13727,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -13999,8 +14125,7 @@
     "fast-redact": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
-      "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg==",
-      "dev": true
+      "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg=="
     },
     "fast-safe-stringify": {
       "version": "2.1.1",
@@ -14029,6 +14154,39 @@
         "secure-json-parse": "^2.0.0",
         "semver": "^7.3.2",
         "tiny-lru": "^7.0.0"
+      },
+      "dependencies": {
+        "pino": {
+          "version": "6.13.4",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.4.tgz",
+          "integrity": "sha512-g4tHSISmQJYUEKEMVdaZ+ZokWwFnTwZL5JPn+lnBVZ1BuBbrSchrXwQINknkM5+Q4fF6U9NjiI8PWwwMDHt9zA==",
+          "dev": true,
+          "requires": {
+            "fast-redact": "^3.0.0",
+            "fast-safe-stringify": "^2.0.8",
+            "flatstr": "^1.0.12",
+            "pino-std-serializers": "^3.1.0",
+            "process-warning": "^1.0.0",
+            "quick-format-unescaped": "^4.0.3",
+            "sonic-boom": "^1.0.2"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+          "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
+          "dev": true
+        },
+        "sonic-boom": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+          "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+          "dev": true,
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "flatstr": "^1.0.12"
+          }
+        }
       }
     },
     "fastify-cors": {
@@ -16775,6 +16933,11 @@
         "isobject": "^3.0.1"
       }
     },
+    "on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -17130,18 +17293,36 @@
       "dev": true
     },
     "pino": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
-      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
-      "dev": true,
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.6.3.tgz",
+      "integrity": "sha512-TCUDiN0QmzruJ5UE4mIFkTcfCSROV7IVRp5SEUH77UnjDHbeoFntj9jQexvYZhCHp1yhjYCH6vZ8rV85L04KaA==",
       "requires": {
         "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.8",
-        "fastify-warning": "^0.2.0",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
         "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.13.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      },
+      "dependencies": {
+        "split2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+          "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
+        }
       }
     },
     "pino-pretty": {
@@ -17165,10 +17346,9 @@
       }
     },
     "pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "pirates": {
       "version": "4.0.4",
@@ -17617,6 +17797,11 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -17694,8 +17879,7 @@
     "quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-      "dev": true
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -17815,6 +17999,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
     },
     "redent": {
       "version": "3.0.0",
@@ -18032,6 +18221,11 @@
           "dev": true
         }
       }
+    },
+    "safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -18413,13 +18607,11 @@
       }
     },
     "sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
-      "dev": true,
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.6.0.tgz",
+      "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
       "requires": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
+        "atomic-sleep": "^1.0.0"
       }
     },
     "source-map": {
@@ -18679,6 +18871,11 @@
         }
       }
     },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -18869,6 +19066,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      }
+    },
+    "thread-stream": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.13.0.tgz",
+      "integrity": "sha512-kTMZeX4Dzlb1zZ00/01aerGaTw2i8NE4sWF0TvF1uXewRhCiUjCvatQkvxIvFqauWG2ADFS2Wpd3qBeYL9i3dg==",
+      "requires": {
+        "real-require": "^0.1.0"
       }
     },
     "throat": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "pg": "^8.7.1",
     "pg-format": "^1.0.4",
     "pgsql-parser": "^13.1.11",
+    "pino": "^7.6.3",
     "prettier": "^2.4.1",
     "prettier-plugin-sql": "^0.4.0",
     "sql-formatter": "^4.0.2"
@@ -47,6 +48,7 @@
     "@types/node": "^14.0.13",
     "@types/pg": "^7.14.3",
     "@types/pg-format": "^1.0.1",
+    "@types/pino": "^7.0.5",
     "cpy-cli": "^3.1.1",
     "crypto-js": "^4.0.0",
     "fastify": "^3.14.0",

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2,9 +2,22 @@ import fastify from 'fastify'
 import { PG_META_EXPORT_DOCS, PG_META_PORT } from './constants'
 import routes from './routes'
 import { extractRequestForLogging } from './utils'
+import pino from 'pino'
 import pkg from '../../package.json'
 
-const app = fastify({ logger: true, disableRequestLogging: true })
+const logger = pino({
+  formatters: {
+    level(label) {
+      return { level: label }
+    },
+  },
+  timestamp: pino.stdTimeFunctions.isoTime,
+})
+
+const app = fastify({
+  logger,
+  disableRequestLogging: true,
+})
 
 app.setErrorHandler((error, request, reply) => {
   app.log.error({ error, request: extractRequestForLogging(request) })


### PR DESCRIPTION
- emit a string level rather than numeric (i.e. 'error' instead of 50)
- emit a readable ISO8601 timestamp instead of unix epoch time

Before:
```
{"level":30,"time":1642458666771,"pid":29532,"hostname":"Divs-MacBook-Pro.local","msg":"App started on port 1337"}                   
```

After:
```
{"level":"info","time":"2022-01-17T23:03:27.847Z","pid":78485,"hostname":"Divs-MacBook-Pro.local","msg":"App started on port 1337"}
```