### PR TITLE
feat: default connection timeout of 15 seconds

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -7,8 +7,10 @@ const PG_META_DB_USER = process.env.PG_META_DB_USER || 'postgres'
 const PG_META_DB_PORT = Number(process.env.PG_META_DB_PORT) || 5432
 const PG_META_DB_PASSWORD = process.env.PG_META_DB_PASSWORD || 'postgres'
 
+const PG_CONN_TIMEOUT_SECS = Number(process.env.PG_CONN_TIMEOUT_SECS || 15)
+
 export const PG_CONNECTION = `postgres://${PG_META_DB_USER}:${PG_META_DB_PASSWORD}@${PG_META_DB_HOST}:${PG_META_DB_PORT}/${PG_META_DB_NAME}?sslmode=disable`
 
 export const PG_META_EXPORT_DOCS = process.env.PG_META_EXPORT_DOCS === 'true' || false
 
-export const DEFAULT_POOL_CONFIG = { max: 1 }
+export const DEFAULT_POOL_CONFIG = { max: 1, connectionTimeoutMillis: PG_CONN_TIMEOUT_SECS * 1000 }


### PR DESCRIPTION
By default there is no timeout, which results in fairly unhelpful
messages from other components in the stack because they do have
limits of e.g. 60s
