### PR TITLE
fix: respond with a 504 if appropriate

### DIFF
--- a/src/server/routes/query.ts
+++ b/src/server/routes/query.ts
@@ -2,7 +2,7 @@ import { FastifyInstance, FastifyRequest } from 'fastify'
 import { PostgresMeta } from '../../lib'
 import * as Parser from '../../lib/Parser'
 import { DEFAULT_POOL_CONFIG } from '../constants'
-import { extractRequestForLogging } from '../utils'
+import { extractRequestForLogging, translateErrorToResponseCode } from '../utils'
 
 const errorOnEmptyQuery = (request: FastifyRequest) => {
   if (!(request.body as any).query) {
@@ -25,7 +25,7 @@ export default async (fastify: FastifyInstance) => {
     await pgMeta.end()
     if (error) {
       request.log.error({ error, request: extractRequestForLogging(request) })
-      reply.code(400)
+      reply.code(translateErrorToResponseCode(error))
       return { error: error.message }
     }
 
@@ -43,7 +43,7 @@ export default async (fastify: FastifyInstance) => {
 
     if (error) {
       request.log.error({ error, request: extractRequestForLogging(request) })
-      reply.code(400)
+      reply.code(translateErrorToResponseCode(error))
       return { error: error.message }
     }
 
@@ -61,7 +61,7 @@ export default async (fastify: FastifyInstance) => {
 
     if (error) {
       request.log.error({ error, request: extractRequestForLogging(request) })
-      reply.code(400)
+      reply.code(translateErrorToResponseCode(error))
       return { error: error.message }
     }
 
@@ -78,7 +78,7 @@ export default async (fastify: FastifyInstance) => {
 
     if (error) {
       request.log.error({ error, request: extractRequestForLogging(request) })
-      reply.code(400)
+      reply.code(translateErrorToResponseCode(error))
       return { error: error.message }
     }
 

--- a/src/server/routes/tables.ts
+++ b/src/server/routes/tables.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify'
 import { PostgresMeta } from '../../lib'
 import { DEFAULT_POOL_CONFIG } from '../constants'
-import { extractRequestForLogging } from '../utils'
+import { extractRequestForLogging, translateErrorToResponseCode } from '../utils'
 
 export default async (fastify: FastifyInstance) => {
   fastify.get<{
@@ -22,7 +22,7 @@ export default async (fastify: FastifyInstance) => {
     await pgMeta.end()
     if (error) {
       request.log.error({ error, request: extractRequestForLogging(request) })
-      reply.code(500)
+      reply.code(translateErrorToResponseCode(error, 500))
       return { error: error.message }
     }
 

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -16,3 +16,13 @@ export const extractRequestForLogging = (request: FastifyRequest) => {
     pg,
   }
 }
+
+export function translateErrorToResponseCode(
+  error: { message: string },
+  defaultResponseCode = 400
+): number {
+  if (error.message === 'Connection terminated due to connection timeout') {
+    return 504
+  }
+  return defaultResponseCode
+}


### PR DESCRIPTION
When we terminate an upstream connection due to a timeout, we ought to
respond with a 504 rather than a 400.