### PR TITLE
fix: handling of type identifier in column create() and update()

### DIFF
--- a/test/lib/columns.ts
+++ b/test/lib/columns.ts
@@ -444,6 +444,53 @@ test('update with name unchanged', async () => {
   await pgMeta.tables.remove(testTable!.id)
 })
 
+test('update with array types', async () => {
+  const { data: testTable } = await pgMeta.tables.create({ name: 't' })
+
+  let res = await pgMeta.columns.create({
+    table_id: testTable!.id,
+    name: 'c',
+    type: 'text',
+  })
+  res = await pgMeta.columns.update(res.data!.id, {
+    type: 'text[]',
+  })
+  expect(res).toMatchInlineSnapshot(
+    {
+      data: {
+        id: expect.stringMatching(/^\d+\.1$/),
+        table_id: expect.any(Number),
+      },
+    },
+    `
+    Object {
+      "data": Object {
+        "comment": null,
+        "data_type": "ARRAY",
+        "default_value": null,
+        "enums": Array [],
+        "format": "_text",
+        "id": StringMatching /\\^\\\\d\\+\\\\\\.1\\$/,
+        "identity_generation": null,
+        "is_generated": false,
+        "is_identity": false,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_updatable": true,
+        "name": "c",
+        "ordinal_position": 1,
+        "schema": "public",
+        "table": "t",
+        "table_id": Any<Number>,
+      },
+      "error": null,
+    }
+  `
+  )
+
+  await pgMeta.tables.remove(testTable!.id)
+})
+
 test('update with incompatible types', async () => {
   const { data: testTable } = await pgMeta.tables.create({ name: 't' })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix [issue 5330](https://github.com/supabase/supabase/issues/5330) of Supabase Upstream. 

## What is the current behavior?
 
Updating column data type from `type` to `type[]`  fails because of insufficient identifier escaping in colum `create` and `update` function.

## Additional context

This is actually a TO-DO  so it's safe to delete the Todo comment now :).