### PR TITLE
fix: date & timestamp format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "pg-format": "^1.0.4",
         "pgsql-parser": "^13.1.11",
         "pino": "^7.6.3",
+        "postgres-array": "^3.0.1",
         "prettier": "^2.4.1",
         "prettier-plugin-sql": "^0.4.0",
         "sql-formatter": "^4.0.2"
@@ -7688,6 +7689,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/pgpass": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
@@ -8170,11 +8179,11 @@
       }
     },
     "node_modules/postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.1.tgz",
+      "integrity": "sha512-h7i53Dw2Yq3a1uuZ6lbVFAkvMMwssJ8jkzeAg0XaZm1XIFF/t/s+tockdqbWTymyEm07dVenOQbFisEi+kj8uA==",
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
       }
     },
     "node_modules/postgres-bytea": {
@@ -17227,6 +17236,13 @@
         "postgres-bytea": "~1.0.0",
         "postgres-date": "~1.0.4",
         "postgres-interval": "^1.1.0"
+      },
+      "dependencies": {
+        "postgres-array": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+          "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+        }
       }
     },
     "pgpass": {
@@ -17595,9 +17611,9 @@
       "dev": true
     },
     "postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.1.tgz",
+      "integrity": "sha512-h7i53Dw2Yq3a1uuZ6lbVFAkvMMwssJ8jkzeAg0XaZm1XIFF/t/s+tockdqbWTymyEm07dVenOQbFisEi+kj8uA=="
     },
     "postgres-bytea": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test": "run-s db:clean db:run test:run db:clean",
     "db:clean": "cd test/db && docker-compose down",
     "db:run": "cd test/db && docker-compose up --detach && sleep 5",
-    "test:run": "jest --runInBand"
+    "test:run": "jest --runInBand",
+    "test:update": "run-s db:clean db:run && jest --runInBand --updateSnapshot && run-s db:clean"
   },
   "engines": {
     "node": ">=14 <15",
@@ -38,6 +39,7 @@
     "pg-format": "^1.0.4",
     "pgsql-parser": "^13.1.11",
     "pino": "^7.6.3",
+    "postgres-array": "^3.0.1",
     "prettier": "^2.4.1",
     "prettier-plugin-sql": "^0.4.0",
     "sql-formatter": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:server": "tsc -p tsconfig.server.json && cpy 'src/lib/sql/*.sql' bin/src/lib/sql",
     "docs:export": "PG_META_EXPORT_DOCS=true ts-node-dev src/server/app.ts",
     "start": "NODE_ENV=production node bin/src/server/app.js",
-    "dev": "run-s db:clean db:run && NODE_ENV=development ts-node-dev src/server/app.ts | pino-pretty --colorize",
+    "dev": "trap 'npm run db:clean' INT && run-s db:clean db:run && NODE_ENV=development ts-node-dev src/server/app.ts | pino-pretty --colorize",
     "pkg": "run-s clean build:server && pkg --out-path bin .pkg.config.json",
     "test": "run-s db:clean db:run test:run db:clean",
     "db:clean": "cd test/db && docker-compose down",

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,7 +1,14 @@
 import { types, Pool, PoolConfig } from 'pg'
+import { parse as parseArray } from 'postgres-array'
 import { PostgresMetaResult } from './types'
 
-types.setTypeParser(20, parseInt)
+types.setTypeParser(types.builtins.INT8, parseInt)
+types.setTypeParser(types.builtins.DATE, (x) => x)
+types.setTypeParser(types.builtins.TIMESTAMP, (x) => x)
+types.setTypeParser(types.builtins.TIMESTAMPTZ, (x) => x)
+types.setTypeParser(1115, parseArray) // _timestamp
+types.setTypeParser(1182, parseArray) // _date
+types.setTypeParser(1185, parseArray) // _timestamptz
 
 export const init: (config: PoolConfig) => {
   query: (sql: string) => Promise<PostgresMetaResult<any>>

--- a/test/lib/roles.ts
+++ b/test/lib/roles.ts
@@ -442,7 +442,7 @@ test('retrieve, create, update, delete', async () => {
         "is_superuser": true,
         "name": "r",
         "password": "********",
-        "valid_until": 2020-01-01T00:00:00.000Z,
+        "valid_until": "2020-01-01 00:00:00+00",
       },
       "error": null,
     }
@@ -467,7 +467,7 @@ test('retrieve, create, update, delete', async () => {
         "is_superuser": true,
         "name": "r",
         "password": "********",
-        "valid_until": 2020-01-01T00:00:00.000Z,
+        "valid_until": "2020-01-01 00:00:00+00",
       },
       "error": null,
     }
@@ -507,7 +507,7 @@ test('retrieve, create, update, delete', async () => {
         "is_superuser": true,
         "name": "rr",
         "password": "********",
-        "valid_until": 2020-01-01T00:00:00.000Z,
+        "valid_until": "2020-01-01 00:00:00+00",
       },
       "error": null,
     }
@@ -532,7 +532,7 @@ test('retrieve, create, update, delete', async () => {
         "is_superuser": true,
         "name": "rr",
         "password": "********",
-        "valid_until": 2020-01-01T00:00:00.000Z,
+        "valid_until": "2020-01-01 00:00:00+00",
       },
       "error": null,
     }


### PR DESCRIPTION
Fixes https://github.com/supabase/postgres-meta/issues/174.

dates, timestamps, and timestamptzs are no longer converted to JS Dates.

date before: "2020-01-01T00:00:00.000Z"

date after: "2020-01-01"