### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
-FROM node:14
+FROM node:14-alpine as deps
+RUN apk add --no-cache bash make git python3
+RUN apk add --update alpine-sdk
 WORKDIR /usr/src/app
 # Do `npm ci` separately so we can cache `node_modules`
 # https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
 COPY package*.json ./
 RUN npm clean-install
+
+FROM node:14-alpine as build
+WORKDIR /usr/src/app
+COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY . .
 RUN npm run build:server
+
+FROM node:14-alpine as prod
+WORKDIR /usr/src/app
+COPY --from=deps /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/bin ./bin
+COPY package.json ./
 ENV PG_META_PORT=8080
 CMD ["npm", "run", "start"]
 EXPOSE 8080


### PR DESCRIPTION
## What kind of change does this PR introduce?

Reduces the total size of the docker image by using node:14-alpine as the base image.

## What is the current behavior?

The image is based on node:14.

## What is the new behavior?

The docker image is smaller (now ~341 MB).
