### PR TITLE
fix: Revert "chore: use slim node base image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:14
 WORKDIR /usr/src/app
 # Do `npm ci` separately so we can cache `node_modules`
 # https://nodejs.org/en/docs/guides/nodejs-docker-webapp/


### PR DESCRIPTION
This reverts commit 26a99800b1dbddd76486f4967a3868327e3dc2c3.
