### PR TITLE
feat: allow end user to turn on ssl mode for db connections

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -6,10 +6,11 @@ const PG_META_DB_NAME = process.env.PG_META_DB_NAME || 'postgres'
 const PG_META_DB_USER = process.env.PG_META_DB_USER || 'postgres'
 const PG_META_DB_PORT = Number(process.env.PG_META_DB_PORT) || 5432
 const PG_META_DB_PASSWORD = process.env.PG_META_DB_PASSWORD || 'postgres'
+const PG_META_DB_SSL_MODE = process.env.PG_META_DB_SSL_MODE|| 'disable'
 
 const PG_CONN_TIMEOUT_SECS = Number(process.env.PG_CONN_TIMEOUT_SECS || 15)
 
-export const PG_CONNECTION = `postgres://${PG_META_DB_USER}:${PG_META_DB_PASSWORD}@${PG_META_DB_HOST}:${PG_META_DB_PORT}/${PG_META_DB_NAME}?sslmode=disable`
+export const PG_CONNECTION = `postgres://${PG_META_DB_USER}:${PG_META_DB_PASSWORD}@${PG_META_DB_HOST}:${PG_META_DB_PORT}/${PG_META_DB_NAME}?sslmode=${PG_META_DB_SSL_MODE}`
 
 export const PG_META_EXPORT_DOCS = process.env.PG_META_EXPORT_DOCS === 'true' || false
 

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -6,7 +6,7 @@ const PG_META_DB_NAME = process.env.PG_META_DB_NAME || 'postgres'
 const PG_META_DB_USER = process.env.PG_META_DB_USER || 'postgres'
 const PG_META_DB_PORT = Number(process.env.PG_META_DB_PORT) || 5432
 const PG_META_DB_PASSWORD = process.env.PG_META_DB_PASSWORD || 'postgres'
-const PG_META_DB_SSL_MODE = process.env.PG_META_DB_SSL_MODE|| 'disable'
+const PG_META_DB_SSL_MODE = process.env.PG_META_DB_SSL_MODE || 'disable'
 
 const PG_CONN_TIMEOUT_SECS = Number(process.env.PG_CONN_TIMEOUT_SECS || 15)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows end user to optionally enable SSL mode on db connections 

## What is the current behavior?

Currently the behavior is to disallow all SSL connections and not provide end user the option to allow them

## What is the new behavior?

New behavior is to default to disallow SSL connections but allow end user to allow them via environment variable

## Additional context

While this app is, as the readme states, intended to run in an unexposed environment, there are still valid use cases for having SSL enabled in these kinds of environments.
