### PR TITLE
feat(lib): omit policies from /tables and allow listing columns from a single table

### DIFF
--- a/src/lib/PostgresMetaTables.ts
+++ b/src/lib/PostgresMetaTables.ts
@@ -1,7 +1,7 @@
 import { ident, literal } from 'pg-format'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
 import { coalesceRowsToArray } from './helpers'
-import { columnsSql, policiesSql, primaryKeysSql, relationshipsSql, tablesSql } from './sql'
+import { columnsSql, primaryKeysSql, relationshipsSql, tablesSql } from './sql'
 import { PostgresMetaResult, PostgresTable } from './types'
 
 export default class PostgresMetaTables {
@@ -229,13 +229,11 @@ COMMIT;`
 const enrichedTablesSql = `
 WITH tables AS (${tablesSql}),
   columns AS (${columnsSql}),
-  policies AS (${policiesSql}),
   primary_keys AS (${primaryKeysSql}),
   relationships AS (${relationshipsSql})
 SELECT
   *,
   ${coalesceRowsToArray('columns', 'columns.table_id = tables.id')},
-  ${coalesceRowsToArray('policies', 'policies.table_id = tables.id')},
   ${coalesceRowsToArray('primary_keys', 'primary_keys.table_id = tables.id')},
   ${coalesceRowsToArray(
     'relationships',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -226,7 +226,6 @@ export const postgresTableSchema = Type.Object({
   dead_rows_estimate: Type.Integer(),
   comment: Type.Union([Type.String(), Type.Null()]),
   columns: Type.Array(postgresColumnSchema),
-  policies: Type.Array(postgresPolicySchema),
   primary_keys: Type.Array(postgresPrimaryKeySchema),
   relationships: Type.Array(postgresRelationshipSchema),
 })

--- a/test/lib/columns.ts
+++ b/test/lib/columns.ts
@@ -31,6 +31,74 @@ test('list', async () => {
   )
 })
 
+test('list from a single table', async () => {
+  const { data: testTable }: any = await pgMeta.tables.create({ name: 't' })
+  await pgMeta.query('alter table t add c1 text, add c2 text')
+
+  const res = await pgMeta.columns.list({ tableId: testTable!.id })
+  expect(res).toMatchInlineSnapshot(
+    {
+      data: [
+        {
+          id: expect.stringMatching(/^\d+\.\d+$/),
+          table_id: expect.any(Number),
+        },
+        {
+          id: expect.stringMatching(/^\d+\.\d+$/),
+          table_id: expect.any(Number),
+        },
+      ],
+    },
+    `
+    Object {
+      "data": Array [
+        Object {
+          "comment": null,
+          "data_type": "text",
+          "default_value": null,
+          "enums": Array [],
+          "format": "text",
+          "id": StringMatching /\\^\\\\d\\+\\\\\\.\\\\d\\+\\$/,
+          "identity_generation": null,
+          "is_generated": false,
+          "is_identity": false,
+          "is_nullable": true,
+          "is_unique": false,
+          "is_updatable": true,
+          "name": "c1",
+          "ordinal_position": 1,
+          "schema": "public",
+          "table": "t",
+          "table_id": Any<Number>,
+        },
+        Object {
+          "comment": null,
+          "data_type": "text",
+          "default_value": null,
+          "enums": Array [],
+          "format": "text",
+          "id": StringMatching /\\^\\\\d\\+\\\\\\.\\\\d\\+\\$/,
+          "identity_generation": null,
+          "is_generated": false,
+          "is_identity": false,
+          "is_nullable": true,
+          "is_unique": false,
+          "is_updatable": true,
+          "name": "c2",
+          "ordinal_position": 2,
+          "schema": "public",
+          "table": "t",
+          "table_id": Any<Number>,
+        },
+      ],
+      "error": null,
+    }
+  `
+  )
+
+  await pgMeta.tables.remove(testTable!.id)
+})
+
 test('retrieve, create, update, delete', async () => {
   const { data: testTable }: any = await pgMeta.tables.create({ name: 't' })
 

--- a/test/lib/tables.ts
+++ b/test/lib/tables.ts
@@ -2,14 +2,13 @@ import { pgMeta } from './utils'
 
 const cleanNondet = (x: any) => {
   const {
-    data: { columns, policies, primary_keys, relationships, ...rest2 },
+    data: { columns, primary_keys, relationships, ...rest2 },
     ...rest1
   } = x
 
   return {
     data: {
       columns: columns.map(({ id, table_id, ...rest }: any) => rest),
-      policies: policies.map(({ id, table_id, ...rest }: any) => rest),
       primary_keys: primary_keys.map(({ table_id, ...rest }: any) => rest),
       relationships: relationships.map(({ id, ...rest }: any) => rest),
       ...rest2,
@@ -21,13 +20,12 @@ const cleanNondet = (x: any) => {
 test('list', async () => {
   const res = await pgMeta.tables.list()
 
-  const { columns, policies, primary_keys, relationships, ...rest }: any = res.data?.find(
+  const { columns, primary_keys, relationships, ...rest }: any = res.data?.find(
     ({ name }) => name === 'users'
   )
 
   expect({
     columns: columns.map(({ id, table_id, ...rest }: any) => rest),
-    policies: policies.map(({ id, table_id, ...rest }: any) => rest),
     primary_keys: primary_keys.map(({ table_id, ...rest }: any) => rest),
     relationships: relationships.map(({ id, ...rest }: any) => rest),
     ...rest,
@@ -103,7 +101,6 @@ test('list', async () => {
       "id": Any<Number>,
       "live_rows_estimate": Any<Number>,
       "name": "users",
-      "policies": Array [],
       "primary_keys": Array [
         Object {
           "name": "id",
@@ -146,7 +143,6 @@ test('retrieve, create, update, delete', async () => {
         "id": Any<Number>,
         "live_rows_estimate": 0,
         "name": "test",
-        "policies": Array [],
         "primary_keys": Array [],
         "relationships": Array [],
         "replica_identity": "DEFAULT",
@@ -172,7 +168,6 @@ test('retrieve, create, update, delete', async () => {
         "id": Any<Number>,
         "live_rows_estimate": 0,
         "name": "test",
-        "policies": Array [],
         "primary_keys": Array [],
         "relationships": Array [],
         "replica_identity": "DEFAULT",
@@ -204,7 +199,6 @@ test('retrieve, create, update, delete', async () => {
         "id": Any<Number>,
         "live_rows_estimate": 0,
         "name": "test a",
-        "policies": Array [],
         "primary_keys": Array [],
         "relationships": Array [],
         "replica_identity": "NOTHING",
@@ -230,7 +224,6 @@ test('retrieve, create, update, delete', async () => {
         "id": Any<Number>,
         "live_rows_estimate": 0,
         "name": "test a",
-        "policies": Array [],
         "primary_keys": Array [],
         "relationships": Array [],
         "replica_identity": "NOTHING",
@@ -269,7 +262,6 @@ test('update with name unchanged', async () => {
         "id": Any<Number>,
         "live_rows_estimate": 0,
         "name": "t",
-        "policies": Array [],
         "primary_keys": Array [],
         "relationships": Array [],
         "replica_identity": "DEFAULT",
@@ -299,7 +291,6 @@ test("allow ' in comments", async () => {
         "id": Any<Number>,
         "live_rows_estimate": 0,
         "name": "t",
-        "policies": Array [],
         "primary_keys": Array [],
         "relationships": Array [],
         "replica_identity": "DEFAULT",
@@ -377,7 +368,6 @@ test('primary keys', async () => {
         "id": Any<Number>,
         "live_rows_estimate": Any<Number>,
         "name": "t",
-        "policies": Array [],
         "primary_keys": Array [
           Object {
             "name": "c",


### PR DESCRIPTION
Listing columns from a single table is done like `GET /columns/:tableId`.