### PR TITLE
fix(lib): parse int8 as string

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,7 +2,14 @@ import { types, Pool, PoolConfig } from 'pg'
 import { parse as parseArray } from 'postgres-array'
 import { PostgresMetaResult } from './types'
 
-types.setTypeParser(types.builtins.INT8, parseInt)
+types.setTypeParser(types.builtins.INT8, (x) => {
+  const asNumber = Number(x)
+  if (Number.isSafeInteger(asNumber)) {
+    return asNumber
+  } else {
+    return x
+  }
+})
 types.setTypeParser(types.builtins.DATE, (x) => x)
 types.setTypeParser(types.builtins.TIMESTAMP, (x) => x)
 types.setTypeParser(types.builtins.TIMESTAMPTZ, (x) => x)

--- a/test/lib/query.ts
+++ b/test/lib/query.ts
@@ -491,3 +491,22 @@ test('formatter', async () => {
     }
   `)
 })
+
+test('very big number', async () => {
+  const res = await pgMeta.query(
+    `SELECT ${Number.MAX_SAFE_INTEGER + 1}::int8, ARRAY[${Number.MIN_SAFE_INTEGER - 1}::int8]`
+  )
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "data": Array [
+        Object {
+          "array": Array [
+            "-9007199254740992",
+          ],
+          "int8": "9007199254740992",
+        },
+      ],
+      "error": null,
+    }
+  `)
+})


### PR DESCRIPTION
Because JS only has float64 numbers.

Pretty hacky solution right now - in the future we should always parse `int8` as `string`.