### PR TITLE
feat: add a secondary port with admin endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.23.4",
+        "fastify-metrics": "^8.0.0",
         "pg": "^8.7.1",
         "pg-format": "^1.0.4",
         "pgsql-parser": "^13.3.0",
@@ -1785,6 +1786,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -3010,11 +3016,19 @@
       "integrity": "sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ==",
       "dev": true
     },
+    "node_modules/fastify-metrics": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-metrics/-/fastify-metrics-8.0.0.tgz",
+      "integrity": "sha512-k0J1cm7gYyidzJMg5g9eIMaq7Bx2nj0yNXtMjnVsIuyctrrONzDBabWOgTG489bXE9a2fZ9xKkaHR0zti1SddA==",
+      "dependencies": {
+        "fastify-plugin": "^3.0.0",
+        "prom-client": "^14.0.0"
+      }
+    },
     "node_modules/fastify-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.0.tgz",
-      "integrity": "sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w==",
-      "dev": true
+      "integrity": "sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w=="
     },
     "node_modules/fastify-static": {
       "version": "4.6.1",
@@ -6962,6 +6976,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+      "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -8106,6 +8131,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/terminal-link": {
@@ -10235,6 +10268,11 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -11211,11 +11249,19 @@
       "integrity": "sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ==",
       "dev": true
     },
+    "fastify-metrics": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-metrics/-/fastify-metrics-8.0.0.tgz",
+      "integrity": "sha512-k0J1cm7gYyidzJMg5g9eIMaq7Bx2nj0yNXtMjnVsIuyctrrONzDBabWOgTG489bXE9a2fZ9xKkaHR0zti1SddA==",
+      "requires": {
+        "fastify-plugin": "^3.0.0",
+        "prom-client": "^14.0.0"
+      }
+    },
     "fastify-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.0.tgz",
-      "integrity": "sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w==",
-      "dev": true
+      "integrity": "sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w=="
     },
     "fastify-static": {
       "version": "4.6.1",
@@ -14194,6 +14240,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prom-client": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+      "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -15053,6 +15107,14 @@
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
+      }
+    },
+    "tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "requires": {
+        "bintrees": "1.0.2"
       }
     },
     "terminal-link": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "^0.23.4",
+    "fastify-metrics": "^8.0.0",
     "pg": "^8.7.1",
     "pg-format": "^1.0.4",
     "pgsql-parser": "^13.3.0",

--- a/src/server/admin-app.ts
+++ b/src/server/admin-app.ts
@@ -1,0 +1,13 @@
+import fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
+
+import _default = require('fastify-metrics')
+
+export function build(opts: FastifyServerOptions = {}): FastifyInstance {
+  const app = fastify(opts)
+  app.register(_default, {
+    endpoint: '/metrics',
+    enableRouteMetrics: false,
+    blacklist: ['nodejs_version_info', 'process_start_time_seconds'],
+  })
+  return app
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -4,6 +4,7 @@ import routes from './routes'
 import { extractRequestForLogging } from './utils'
 import pino from 'pino'
 import pkg from '../../package.json'
+import { build as buildAdminApp } from './admin-app'
 
 const logger = pino({
   formatters: {
@@ -57,6 +58,11 @@ if (PG_META_EXPORT_DOCS) {
   app.ready(() => {
     app.listen(PG_META_PORT, '0.0.0.0', () => {
       app.log.info(`App started on port ${PG_META_PORT}`)
+      const adminApp = buildAdminApp({ logger })
+      const adminPort = PG_META_PORT + 1
+      adminApp.listen(adminPort, '0.0.0.0', () => {
+        adminApp.log.info(`Admin App started on port ${adminPort}`)
+      })
     })
   })
 }


### PR DESCRIPTION
The first endpoint included is for metrics using the prometheus
exposition format.