### PR TITLE
feat: support docker file-based secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,6 @@ COPY --from=build /usr/src/app/node_modules node_modules
 COPY --from=build /usr/src/app/bin bin
 COPY package.json ./
 ENV PG_META_PORT=8080
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["npm", "run", "start"]
 EXPOSE 8080

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# load secrets either from environment variables or files
+file_env 'PG_META_DB_PASSWORD'
+
+exec "${@}"
+


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add an entry point file `docker-entrypoint.sh` to Docker image, which will enable use of Docker file-based secrets as mentioned in https://github.com/supabase/supabase/issues/6014.

## What is the current behavior?

Currently this Docker image only supports environment variable based secrets, file-based secrets `*_FILE` are not supported but is suggested by Docker in https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images.

## What is the new behavior?

File-based Docker secrets `*_FILE` will be supported and fall back to environment variable secrets.

## Additional context

N/A
