### PR TITLE
feat: support IPv6 address binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Helpers:
 Set the following ENV VARS:
 
 ```bash
+PG_META_HOST="0.0.0.0"
 PG_META_PORT=8080
 PG_META_DB_HOST="postgres"
 PG_META_DB_NAME="postgres"

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -6,6 +6,7 @@ import {
   GENERATE_TYPES,
   GENERATE_TYPES_INCLUDED_SCHEMAS,
   PG_CONNECTION,
+  PG_META_HOST,
   PG_META_PORT,
   PG_META_REQ_HEADER,
 } from './constants'
@@ -106,11 +107,11 @@ if (EXPORT_DOCS) {
   })()
 } else {
   app.ready(() => {
-    app.listen(PG_META_PORT, '0.0.0.0', () => {
+    app.listen(PG_META_PORT, PG_META_HOST, () => {
       app.log.info(`App started on port ${PG_META_PORT}`)
       const adminApp = buildAdminApp({ logger })
       const adminPort = PG_META_PORT + 1
-      adminApp.listen(adminPort, '0.0.0.0', () => {
+      adminApp.listen(adminPort, PG_META_HOST, () => {
         adminApp.log.info(`Admin App started on port ${adminPort}`)
       })
     })

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -1,3 +1,4 @@
+export const PG_META_HOST = process.env.PG_META_HOST || '0.0.0.0'
 export const PG_META_PORT = Number(process.env.PG_META_PORT || 1337)
 export const CRYPTO_KEY = process.env.CRYPTO_KEY || 'SAMPLE_KEY'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Non breaking change that adds an environment variable to control fastify host. This unlocks connections using IPv6 connections by setting `PG_META_HOST` as `::`.

## What is the current behavior?

Current configuration only allows IPv4 port binding. See https://www.fastify.io/docs/latest/Reference/Server/#listen

## What is the new behavior?

Configuration can be set to support IPv6 binding.
