### PR TITLE
fix(lib/publications): check error before indexing array

### DIFF
--- a/src/lib/PostgresMetaPublications.ts
+++ b/src/lib/PostgresMetaPublications.ts
@@ -226,6 +226,9 @@ end $$;
 with publications as (${publicationsSql}) select * from publications where name = (select name from pg_meta_publication_tmp);
 `
     const { data, error } = await this.query(sql)
+    if (error) {
+      return { data: null, error }
+    }
     return { data: data[0], error }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When there is an error on `PATCH /publications`, the actual error is hidden by `data[0]` where `data` is `null`. The error returned becomes:

```
Cannot read properties of null (reading '0')
```

## What is the new behavior?

The error becomes the actual error, e.g.:

```
must be owner of publication supabase_realtime
```