### PR TITLE
fix: support schemas query param for listing tables

### DIFF
--- a/src/lib/PostgresMetaTables.ts
+++ b/src/lib/PostgresMetaTables.ts
@@ -13,15 +13,19 @@ export default class PostgresMetaTables {
 
   async list({
     includeSystemSchemas = false,
+    schemas,
     limit,
     offset,
   }: {
     includeSystemSchemas?: boolean
+    schemas?: string[]
     limit?: number
     offset?: number
   } = {}): Promise<PostgresMetaResult<PostgresTable[]>> {
     let sql = enrichedTablesSql
-    if (!includeSystemSchemas) {
+    if (schemas) {
+      sql = `${sql} WHERE (schema IN (${schemas.map(literal).join(',')}))`
+    } else if (!includeSystemSchemas) {
       sql = `${sql} WHERE NOT (schema IN (${DEFAULT_SYSTEM_SCHEMAS.map(literal).join(',')}))`
     }
     if (limit) {

--- a/src/server/routes/tables.ts
+++ b/src/server/routes/tables.ts
@@ -18,7 +18,12 @@ export default async (fastify: FastifyInstance) => {
     const { schemas, limit, offset } = request.query
 
     const pgMeta = new PostgresMeta({ ...DEFAULT_POOL_CONFIG, connectionString })
-    const { data, error } = await pgMeta.tables.list({ includeSystemSchemas, schemas, limit, offset })
+    const { data, error } = await pgMeta.tables.list({
+      includeSystemSchemas,
+      schemas,
+      limit,
+      offset,
+    })
     await pgMeta.end()
     if (error) {
       request.log.error({ error, request: extractRequestForLogging(request) })

--- a/src/server/routes/tables.ts
+++ b/src/server/routes/tables.ts
@@ -8,17 +8,17 @@ export default async (fastify: FastifyInstance) => {
     Headers: { pg: string }
     Querystring: {
       include_system_schemas?: string
+      schemas?: string[]
       limit?: number
       offset?: number
     }
   }>('/', async (request, reply) => {
     const connectionString = request.headers.pg
     const includeSystemSchemas = request.query.include_system_schemas === 'true'
-    const limit = request.query.limit
-    const offset = request.query.offset
+    const { schemas, limit, offset } = request.query
 
     const pgMeta = new PostgresMeta({ ...DEFAULT_POOL_CONFIG, connectionString })
-    const { data, error } = await pgMeta.tables.list({ includeSystemSchemas, limit, offset })
+    const { data, error } = await pgMeta.tables.list({ includeSystemSchemas, schemas, limit, offset })
     await pgMeta.end()
     if (error) {
       request.log.error({ error, request: extractRequestForLogging(request) })

--- a/test/lib/tables.ts
+++ b/test/lib/tables.ts
@@ -17,6 +17,12 @@ const cleanNondet = (x: any) => {
   }
 }
 
+test('list schemas', async () => {
+  const res = await pgMeta.tables.list({ schemas: ['private'] })
+  const data = res.data?.find(({ name }) => name === 'users')
+  expect(data).toBeUndefined()
+})
+
 test('list', async () => {
   const res = await pgMeta.tables.list()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature https://www.notion.so/supabase/pg-meta-tables-support-fetching-tables-from-a-specified-schema-6ac33f9b73a542158f0a31bf25399bd7

## What is the current behavior?

all schemas are included when listing tables

## What is the new behavior?

supporting listing tables of specific schemas

## Additional context

Add any other context or screenshots.
