### PR TITLE
chore: switch build to esnext module type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16 as build
 WORKDIR /usr/src/app
 # Do `npm ci` separately so we can cache `node_modules`
 # https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
 RUN npm clean-install
 COPY . .
 RUN npm run build:server

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/*.test.ts']
-}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",
   "repository": "supabase/postgres-meta",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,13 @@
     "node": ">=16",
     "npm": ">=8"
   },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/*.test.ts"
+    ]
+  },
   "dependencies": {
     "@sinclair/typebox": "^0.25.1",
     "pg": "^8.7.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,11 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "module": "CommonJS",
+    "module": "esnext",
     "outDir": "dist/main",
     "rootDir": "src/lib",
     "sourceMap": true,
-    "target": "ES2015",
+    "target": "esnext",
 
     "strict": true,
 

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "module": "ES2015",
+    "module": "esnext",
     "outDir": "dist/module"
   }
 }

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
-    "module": "CommonJS",
+    "module": "esnext",
     "outDir": "bin",
     "sourceMap": true,
-    "target": "ES2015",
+    "target": "esnext",
 
     "strict": true,
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

build

## What is the current behavior?

commonjs

## What is the new behavior?

no need to support commonjs as pg-meta is purely server side

## Additional context

Add any other context or screenshots.
