### PR TITLE
fix: #752 mark optional function parameters for typescript gen

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -102,6 +102,7 @@ const postgresFunctionSchema = Type.Object({
       ]),
       name: Type.String(),
       type_id: Type.Number(),
+      has_default: Type.Boolean(),
     })
   ),
   argument_types: Type.String(),

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -227,7 +227,7 @@ export interface Database {
                       return 'Record<PropertyKey, never>'
                     }
 
-                    const argsNameAndType = inArgs.map(({ name, type_id }) => {
+                    const argsNameAndType = inArgs.map(({ name, type_id, has_default }) => {
                       let type = arrayTypes.find(({ id }) => id === type_id)
                       if (type) {
                         // If it's an array type, the name looks like `_int8`.
@@ -235,17 +235,23 @@ export interface Database {
                         return {
                           name,
                           type: `(${pgTypeToTsType(elementTypeName, types, schemas)})[]`,
+                          has_default,
                         }
                       }
                       type = types.find(({ id }) => id === type_id)
                       if (type) {
-                        return { name, type: pgTypeToTsType(type.name, types, schemas) }
+                        return {
+                          name,
+                          type: pgTypeToTsType(type.name, types, schemas),
+                          has_default,
+                        }
                       }
-                      return { name, type: 'unknown' }
+                      return { name, type: 'unknown', has_default }
                     })
 
                     return `{ ${argsNameAndType.map(
-                      ({ name, type }) => `${JSON.stringify(name)}: ${type}`
+                      ({ name, type, has_default }) =>
+                        `${JSON.stringify(name)}${has_default ? '?' : ''}: ${type}`
                     )} }`
                   })()}
                   Returns: ${(() => {

--- a/test/lib/functions.ts
+++ b/test/lib/functions.ts
@@ -8,11 +8,13 @@ test('list', async () => {
     {
       "args": [
         {
+          "has_default": false,
           "mode": "in",
           "name": "",
           "type_id": 23,
         },
         {
+          "has_default": false,
           "mode": "in",
           "name": "",
           "type_id": 23,
@@ -98,11 +100,13 @@ test('retrieve, create, update, delete', async () => {
       "data": {
         "args": [
           {
+            "has_default": false,
             "mode": "in",
             "name": "a",
             "type_id": 21,
           },
           {
+            "has_default": false,
             "mode": "in",
             "name": "b",
             "type_id": 21,
@@ -143,11 +147,13 @@ test('retrieve, create, update, delete', async () => {
       "data": {
         "args": [
           {
+            "has_default": false,
             "mode": "in",
             "name": "a",
             "type_id": 21,
           },
           {
+            "has_default": false,
             "mode": "in",
             "name": "b",
             "type_id": 21,
@@ -192,11 +198,13 @@ test('retrieve, create, update, delete', async () => {
       "data": {
         "args": [
           {
+            "has_default": false,
             "mode": "in",
             "name": "a",
             "type_id": 21,
           },
           {
+            "has_default": false,
             "mode": "in",
             "name": "b",
             "type_id": 21,
@@ -237,11 +245,13 @@ test('retrieve, create, update, delete', async () => {
       "data": {
         "args": [
           {
+            "has_default": false,
             "mode": "in",
             "name": "a",
             "type_id": 21,
           },
           {
+            "has_default": false,
             "mode": "in",
             "name": "b",
             "type_id": 21,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix for #752, generating typescript types for a Postgres function with optional parameters.

## What is the current behavior?

A Postgres functions with optional parameters will output as required parameters, e.g. `p_user_id: string`.

## What is the new behavior?

The typescript output will mark optional parameters as optional, e.g. `p_user_id?: string`.

## Additional context

See bug for repro setup.