### PR TITLE
feat: composite type attributes

### DIFF
--- a/src/lib/sql/types.sql
+++ b/src/lib/sql/types.sql
@@ -1,33 +1,47 @@
-SELECT
-  t.oid :: int8 AS id,
-  t.typname AS name,
-  n.nspname AS schema,
-  format_type (t.oid, NULL) AS format,
-  array_to_json(
-    array(
-      SELECT
-        e.enumlabel
-      FROM
-        pg_enum e
-      WHERE
-        e.enumtypid = t.oid
-      ORDER BY
-        e.oid
-    )
-  ) AS enums,
-  obj_description (t.oid, 'pg_type') AS comment
-FROM
+select
+  t.oid::int8 as id,
+  t.typname as name,
+  n.nspname as schema,
+  format_type (t.oid, null) as format,
+  coalesce(t_enums.enums, '[]') as enums,
+  coalesce(t_attributes.attributes, '[]') as attributes,
+  obj_description (t.oid, 'pg_type') as comment
+from
   pg_type t
-  LEFT JOIN pg_namespace n ON n.oid = t.typnamespace
-WHERE
+  left join pg_namespace n on n.oid = t.typnamespace
+  left join (
+    select
+      enumtypid,
+      jsonb_agg(enumlabel order by enumsortorder) as enums
+    from
+      pg_enum
+    group by
+      enumtypid
+  ) as t_enums on t_enums.enumtypid = t.oid
+  left join (
+    select
+      oid,
+      jsonb_agg(
+        jsonb_build_object('name', a.attname, 'type_id', a.atttypid::int8)
+        order by a.attnum asc
+      ) as attributes
+    from
+      pg_class c
+      join pg_attribute a on a.attrelid = c.oid
+    where
+      c.relkind = 'c'
+    group by
+      c.oid
+  ) as t_attributes on t_attributes.oid = t.typrelid
+where
   (
     t.typrelid = 0
-    OR (
-      SELECT
+    or (
+      select
         c.relkind = 'c'
-      FROM
+      from
         pg_class c
-      WHERE
+      where
         c.oid = t.typrelid
     )
   )

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -37,7 +37,7 @@ export const postgresColumnSchema = Type.Object({
   is_nullable: Type.Boolean(),
   is_updatable: Type.Boolean(),
   is_unique: Type.Boolean(),
-  enums: Type.Array(Type.Unknown()),
+  enums: Type.Array(Type.String()),
   comment: Type.Union([Type.String(), Type.Null()]),
 })
 export type PostgresColumn = Static<typeof postgresColumnSchema>
@@ -326,7 +326,13 @@ export const postgresTypeSchema = Type.Object({
   name: Type.String(),
   schema: Type.String(),
   format: Type.String(),
-  enums: Type.Array(Type.Unknown()),
+  enums: Type.Array(Type.String()),
+  attributes: Type.Array(
+    Type.Object({
+      name: Type.String(),
+      type_id: Type.Integer(),
+    })
+  ),
   comment: Type.Union([Type.String(), Type.Null()]),
 })
 export type PostgresType = Static<typeof postgresTypeSchema>

--- a/test/lib/types.ts
+++ b/test/lib/types.ts
@@ -5,8 +5,8 @@ test('list', async () => {
   expect(res.data?.find(({ name }) => name === 'user_status')).toMatchInlineSnapshot(
     { id: expect.any(Number) },
     `
-    Object {
-      "attributes": Array [],
+    {
+      "attributes": [],
       "comment": null,
       "enums": [
         "ACTIVE",
@@ -63,19 +63,19 @@ test('composite type attributes', async () => {
   expect(res.data?.find(({ name }) => name === 'test_composite')).toMatchInlineSnapshot(
     { id: expect.any(Number) },
     `
-    Object {
-      "attributes": Array [
-        Object {
+    {
+      "attributes": [
+        {
           "name": "id",
           "type_id": 20,
         },
-        Object {
+        {
           "name": "data",
           "type_id": 25,
         },
       ],
       "comment": null,
-      "enums": Array [],
+      "enums": [],
       "format": "test_composite",
       "id": Any<Number>,
       "name": "test_composite",

--- a/test/lib/types.ts
+++ b/test/lib/types.ts
@@ -5,7 +5,8 @@ test('list', async () => {
   expect(res.data?.find(({ name }) => name === 'user_status')).toMatchInlineSnapshot(
     { id: expect.any(Number) },
     `
-    {
+    Object {
+      "attributes": Array [],
       "comment": null,
       "enums": [
         "ACTIVE",
@@ -53,4 +54,35 @@ test('list types with excluded schemas and include System Schemas', async () => 
   res.data?.forEach((type) => {
     expect(type.schema).not.toBe('public')
   })
+})
+
+test('composite type attributes', async () => {
+  await pgMeta.query(`create type test_composite as (id int8, data text);`)
+
+  const res = await pgMeta.types.list()
+  expect(res.data?.find(({ name }) => name === 'test_composite')).toMatchInlineSnapshot(
+    { id: expect.any(Number) },
+    `
+    Object {
+      "attributes": Array [
+        Object {
+          "name": "id",
+          "type_id": 20,
+        },
+        Object {
+          "name": "data",
+          "type_id": 25,
+        },
+      ],
+      "comment": null,
+      "enums": Array [],
+      "format": "test_composite",
+      "id": Any<Number>,
+      "name": "test_composite",
+      "schema": "public",
+    }
+  `
+  )
+
+  await pgMeta.query(`drop type test_composite;`)
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Attributes of [composite types](https://www.postgresql.org/docs/current/rowtypes.html) are not returned

## What is the new behavior?

Add an `attributes` field for composite types. Also add `CompositeTypes` for each schema in the generated types.

## Additional context

Closes #399 
