### PR TITLE
feat: support citext data type when generating typescript types

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -322,6 +322,7 @@ const pgTypeToTsType = (
       'varchar',
       'date',
       'text',
+      'citext',
       'time',
       'timetz',
       'timestamp',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

When generating TypeScript types (`supabase gen types typescript`), columns with `citext` (case insensitive text) data type show up as `unknown`.

## What is the new behavior?

Columns with `citext` data type will now show up as `string`.

## Additional context

Added `citext` to list of types that will generate a `string` TypeScript type. Also confirmed that [this query](https://github.com/supabase/postgres-meta/blob/42d3ea7910358d57be365355632195a7c50199d4/src/lib/sql/columns.sql#L28) does in fact output `citext` under `format` when the column has `citext` data type as is referenced [here](https://github.com/supabase/postgres-meta/blob/42d3ea7910358d57be365355632195a7c50199d4/src/server/templates/typescript.ts#L77).
