### PR TITLE
Add HEALTHCHECK to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,5 @@ COPY package.json ./
 ENV PG_META_PORT=8080
 CMD ["npm", "run", "start"]
 EXPOSE 8080
+# --start-period defaults to 0s, but can't be set to 0s (to be explicit) by now
+HEALTHCHECK --interval=5s --timeout=5s --retries=3 CMD curl -f http://localhost:8080/health || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ENV PG_META_PORT=8080
 CMD ["npm", "run", "start"]
 EXPOSE 8080
 # --start-period defaults to 0s, but can't be set to 0s (to be explicit) by now
-HEALTHCHECK --interval=5s --timeout=5s --retries=3 CMD curl -f http://localhost:8080/health || exit 1
+HEALTHCHECK --interval=5s --timeout=5s --retries=3 CMD node -e "require('http').get('http://localhost:8080/health', (r) => {if (r.statusCode !== 200) throw new Error(r.statusCode)})"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature. Add `HEALTHCHECK` to `Dockerfile`
1. There is `/health` endpoint
2. Why not?

## What is the current behavior?

No issue

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Set interval and timeout to 5 seconds, is it ok?
