### PR TITLE
Make function return types nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ To start developing, run `npm run dev`. It will set up the database with Docker 
 
 If you are fixing a bug, you should create a new test case. To test your changes, add the `-u/--updateSnapshot` flag to `jest` on the `test:run` script, run `npm run test`, and then review the git diff of the snapshots. Depending on your change, you may see `id` fields being changed - this is expected and you are free to commit it, as long as it passes the CI. Don't forget to remove the `-u/--updateSnapshot` flag when committing.
 
+To make changes to the TypeScript type generation, run `npm run gen:types:typescript` while you have `npm run dev` running.
+
 ## Licence
 
 Apache 2.0

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -90,7 +90,7 @@ export interface Database {
                               fn.return_type,
                               types,
                               schemas
-                            )}`
+                            )} | null`
                         ),
                     ]}
                   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Makes all table function column return types nullable.

## What is the current behavior?

The verbatim function types are used as column types despite the functions potentially returning `null`.

## What is the new behavior?

All return types are treated as nullable.

## Additional context

@psteinroe contributed a change which adds schema functions which take only the table name as columns on the tables when generating TypeScript types.

This commit extends that to treat function return types as nullable.

The function used in `oo-init.sql` could be changed like so:

```sql
create function public.blurb(public.todos) returns text as
$$
select null;
$$ language sql stable;
```

It would still compile and be a valid function despite the unchanged return type, which means any function must be treated as potentially returning `null` in the types.

I have also updated instructions for building and testing the TypeScript type generation.

Here's how I tested this:

- Run `npm install` and `npm run dev` to spin up the Docker container and the code watcher
- Run `npm run gen:types:typescript` to hit the endpoint that generates the TypeScript types
- Make the change in `src/server/templates/typescript.ts` and re-run the above
- Check the output of the above command to see what the new generated response looks like
