### PR TITLE
fix: add "types" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "type": "module",
   "main": "dist/server/app.js",
+  "types": "dist/lib/types.d.ts",
   "imports": {
     "#package.json": "./package.json"
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.
Types are not exported by default so adding `types` field to package.json.
Resolves this issue: https://github.com/supabase/supabase/actions/runs/3980851540/jobs/6824193248

Tested locally by manually adding this field in node_modules, works.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
