### PR TITLE
fix: Fix logic when returning default roles

### DIFF
--- a/src/lib/PostgresMetaRoles.ts
+++ b/src/lib/PostgresMetaRoles.ts
@@ -1,5 +1,4 @@
 import { ident, literal } from 'pg-format'
-import { DEFAULT_ROLES } from './constants.js'
 import { rolesSql } from './sql/index.js'
 import {
   PostgresMetaResult,
@@ -43,7 +42,15 @@ FROM
 WHERE
   true`
     if (!includeDefaultRoles) {
-      sql += ` AND name NOT IN (${DEFAULT_ROLES.map(literal).join(',')})`
+      // All default/predefined roles start with pg_: https://www.postgresql.org/docs/15/predefined-roles.html
+      // The pg_ prefix is also reserved:
+      //
+      // ```
+      // postgres=# create role pg_mytmp;
+      // ERROR:  role name "pg_mytmp" is reserved
+      // DETAIL:  Role names starting with "pg_" are reserved.
+      // ```
+      sql += ` AND NOT pg_catalog.starts_with(name, 'pg_')`
     }
     if (limit) {
       sql += ` LIMIT ${limit}`

--- a/src/lib/PostgresMetaRoles.ts
+++ b/src/lib/PostgresMetaRoles.ts
@@ -42,7 +42,7 @@ FROM
   roles
 WHERE
   true`
-    if (includeDefaultRoles) {
+    if (!includeDefaultRoles) {
       sql += ` AND name NOT IN (${DEFAULT_ROLES.map(literal).join(',')})`
     }
     if (limit) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,14 +1,3 @@
-export const DEFAULT_ROLES = [
-  'pg_execute_server_program',
-  'pg_monitor',
-  'pg_read_all_settings',
-  'pg_read_all_stats',
-  'pg_read_server_files',
-  'pg_signal_backend',
-  'pg_stat_scan_tables',
-  'pg_write_server_files',
-]
-
 export const DEFAULT_SYSTEM_SCHEMAS = [
   'information_schema',
   'pg_catalog',

--- a/test/lib/roles.ts
+++ b/test/lib/roles.ts
@@ -3,7 +3,7 @@ import { pgMeta } from './utils'
 test('list', async () => {
   const res = await pgMeta.roles.list()
 
-  const role: any = res.data?.find(({ name }) => name === 'postgres')
+  let role = res.data?.find(({ name }) => name === 'postgres')
 
   expect(role).toMatchInlineSnapshot(
     { active_connections: expect.any(Number), id: expect.any(Number) },
@@ -21,6 +21,43 @@ test('list', async () => {
       "is_replication_role": true,
       "is_superuser": true,
       "name": "postgres",
+      "password": "********",
+      "valid_until": null,
+    }
+  `
+  )
+
+  // pg_monitor is a predefined role. `includeDefaultRoles` defaults to false,
+  // so it shouldn't be included in the result.
+  role = res.data?.find(({ name }) => name === 'pg_monitor')
+
+  expect(role).toMatchInlineSnapshot(`undefined`)
+})
+
+test('list w/ default roles', async () => {
+  const res = await pgMeta.roles.list({ includeDefaultRoles: true })
+
+  const role = res.data?.find(({ name }) => name === 'pg_monitor')
+
+  expect(role).toMatchInlineSnapshot(
+    {
+      active_connections: expect.any(Number),
+      id: expect.any(Number),
+    },
+    `
+    {
+      "active_connections": Any<Number>,
+      "can_bypass_rls": false,
+      "can_create_db": false,
+      "can_create_role": false,
+      "can_login": false,
+      "config": null,
+      "connection_limit": 100,
+      "id": Any<Number>,
+      "inherit_role": true,
+      "is_replication_role": false,
+      "is_superuser": false,
+      "name": "pg_monitor",
       "password": "********",
       "valid_until": null,
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.
Fixes logic with `includeDefaultRoles`. Actually a breaking change.
Maybe I should change `includeDefaultRoles` to `true` to not change the behavior?

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
