### PR TITLE
Skip over dropped attributes when enumerating types

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ To start developing, run `npm run dev`. It will set up the database with Docker 
 If you are fixing a bug, you should create a new test case. To test your changes, add the `-u/--updateSnapshot` flag to `jest` on the `test:run` script, run `npm run test`, and then review the git diff of the snapshots. Depending on your change, you may see `id` fields being changed - this is expected and you are free to commit it, as long as it passes the CI. Don't forget to remove the `-u/--updateSnapshot` flag when committing.
 
 To make changes to the TypeScript type generation, run `npm run gen:types:typescript` while you have `npm run dev` running.
+To use your own database connection string instead of the provided test database, run:
+`PG_META_DB_URL=postgresql://postgres:postgres@localhost:5432/postgres npm run gen:types:typescript`
 
 ## Licence
 

--- a/src/lib/sql/types.sql
+++ b/src/lib/sql/types.sql
@@ -29,7 +29,7 @@ from
       pg_class c
       join pg_attribute a on a.attrelid = c.oid
     where
-      c.relkind = 'c'
+      c.relkind = 'c' and a.attisdropped = false
     group by
       c.oid
   ) as t_attributes on t_attributes.oid = t.typrelid

--- a/src/lib/sql/types.sql
+++ b/src/lib/sql/types.sql
@@ -29,7 +29,7 @@ from
       pg_class c
       join pg_attribute a on a.attrelid = c.oid
     where
-      c.relkind = 'c' and a.attisdropped = false
+      c.relkind = 'c' and not a.attisdropped
     group by
       c.oid
   ) as t_attributes on t_attributes.oid = t.typrelid


### PR DESCRIPTION
`pg_attribute` may contain records for attributes that were dropped but Postgres kept them around and instead of deleting them, renamed them to `........pg.dropped.#........` and set their `attisdropped` to `true`.

This ends up generating these dropped attributes as `unknown` fields in the TypeScript types.

In this commit I updated the `types` query to not return these.

Maybe it would be preferrable to instead keep these but skip them only when generating the TypeScript types?

## What kind of change does this PR introduce?

Feature? Maybe bug fix?

It is arguable whether these dropped attributes should appear in the generated types and be accessible via the Postgres Meta API. I expect folks might lean towards exposing them instead of skipping them. In this case I'd like to contribute a change which adds a new `dropped` boolean field on `types` and then skips over `dropped` types when generating composite types via the TypeScript generator.

## What is the current behavior?

Dropped attributes appear in generated TypeScript types.
It used to be that they would appear just as a line saying `unknown;`.
This seems to have been fixed on `master`, not they actually display the renamed name:

```typescript
message_input: {
  "........pg.dropped.11........": unknown
}
```

See #483 for the PR that fixed this.

Yet these are not useful in the types since they are dropped and I happen to think they shouldn't be in the TypeScript types. It is arguable whether they should be in `pgMeta.types.list`. I can see an argument for both cases.

## What is the new behavior?

`pgMeta.types.list` skips over `attisdropped=true` attributes.
As a result, the TypeScript types skip over them as well when generating composite types (among other types?).
I am happy to change the PR to instead skip over these at the TypeScript generator level so they remain accessible in `pgMeta.types.list`.