### PR TITLE
chore: add workflow to publish binary dependencies

### DIFF
--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -1,0 +1,27 @@
+name: Publish Dependencies
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'pyramation/libpg-query-node'
+          ref: 'v13'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - run: npm i
+      - run: npm run binary:build
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
+          aws-region: us-east-1
+
+      - run: npx node-pre-gyp publish

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   publish:
+    # Must match glibc verison in node:16-bullseye
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as build
+FROM node:16-bullseye as build
 WORKDIR /usr/src/app
 # Do `npm ci` separately so we can cache `node_modules`
 # https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
@@ -7,7 +7,7 @@ RUN npm clean-install
 COPY . .
 RUN npm run build
 
-FROM node:16-slim
+FROM node:16-bullseye-slim
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/node_modules node_modules
 COPY --from=build /usr/src/app/dist dist


### PR DESCRIPTION
## What kind of change does this PR introduce?

build and publish binary deps

## What is the current behavior?

binaries are built locally

## What is the new behavior?

add GHA workflow for auto publishing

## Additional context

Add any other context or screenshots.
