### PR TITLE
feat: support vector data type when generating typescript types

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -405,6 +405,8 @@ const pgTypeToTsType = (
     return 'undefined'
   } else if (pgType === 'record') {
     return 'Record<string, unknown>'
+  } else if (pgType === 'vector') {
+    return 'number[]'
   } else if (pgType.startsWith('_')) {
     return `(${pgTypeToTsType(pgType.substring(1), types, schemas)})[]`
   } else {

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -396,6 +396,7 @@ const pgTypeToTsType = (
       'timestamp',
       'timestamptz',
       'uuid',
+      'vector',
     ].includes(pgType)
   ) {
     return 'string'
@@ -405,8 +406,6 @@ const pgTypeToTsType = (
     return 'undefined'
   } else if (pgType === 'record') {
     return 'Record<string, unknown>'
-  } else if (pgType === 'vector') {
-    return 'number[]'
   } else if (pgType.startsWith('_')) {
     return `(${pgTypeToTsType(pgType.substring(1), types, schemas)})[]`
   } else {


### PR DESCRIPTION
Adds pgvector's `vector` data type to TypeScript generation logic to produce a ~~`number[]`~~ `string` type.

Edit: `vector` actually produces a `string`, eg `"[1,2,3]"`.