### PR TITLE
feat(typegen): table relationships

### DIFF
--- a/src/lib/PostgresMeta.ts
+++ b/src/lib/PostgresMeta.ts
@@ -8,6 +8,7 @@ import PostgresMetaFunctions from './PostgresMetaFunctions.js'
 import PostgresMetaMaterializedViews from './PostgresMetaMaterializedViews.js'
 import PostgresMetaPolicies from './PostgresMetaPolicies.js'
 import PostgresMetaPublications from './PostgresMetaPublications.js'
+import PostgresMetaRelationships from './PostgresMetaRelationships.js'
 import PostgresMetaRoles from './PostgresMetaRoles.js'
 import PostgresMetaSchemas from './PostgresMetaSchemas.js'
 import PostgresMetaTables from './PostgresMetaTables.js'
@@ -29,6 +30,7 @@ export default class PostgresMeta {
   materializedViews: PostgresMetaMaterializedViews
   policies: PostgresMetaPolicies
   publications: PostgresMetaPublications
+  relationships: PostgresMetaRelationships
   roles: PostgresMetaRoles
   schemas: PostgresMetaSchemas
   tables: PostgresMetaTables
@@ -53,6 +55,7 @@ export default class PostgresMeta {
     this.materializedViews = new PostgresMetaMaterializedViews(this.query)
     this.policies = new PostgresMetaPolicies(this.query)
     this.publications = new PostgresMetaPublications(this.query)
+    this.relationships = new PostgresMetaRelationships(this.query)
     this.roles = new PostgresMetaRoles(this.query)
     this.schemas = new PostgresMetaSchemas(this.query)
     this.tables = new PostgresMetaTables(this.query)

--- a/src/lib/PostgresMetaRelationships.ts
+++ b/src/lib/PostgresMetaRelationships.ts
@@ -1,0 +1,27 @@
+import { relationshipsSql } from './sql/index.js'
+import { PostgresMetaResult, PostgresRelationship } from './types.js'
+
+export default class PostgresMetaRelationships {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    limit,
+    offset,
+  }: {
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresRelationship[]>> {
+    let sql = relationshipsSql
+    if (limit) {
+      sql = `${sql} LIMIT ${limit}`
+    }
+    if (offset) {
+      sql = `${sql} OFFSET ${offset}`
+    }
+    return await this.query(sql)
+  }
+}

--- a/src/lib/PostgresMetaTables.ts
+++ b/src/lib/PostgresMetaTables.ts
@@ -1,7 +1,7 @@
 import { ident, literal } from 'pg-format'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
 import { coalesceRowsToArray, filterByList } from './helpers.js'
-import { columnsSql, primaryKeysSql, relationshipsSql, tablesSql } from './sql/index.js'
+import { columnsSql, primaryKeysSql, relationshipsOldSql, tablesSql } from './sql/index.js'
 import {
   PostgresMetaResult,
   PostgresTable,
@@ -251,7 +251,7 @@ const generateEnrichedTablesSql = ({ includeColumns }: { includeColumns: boolean
 with tables as (${tablesSql})
   ${includeColumns ? `, columns as (${columnsSql})` : ''}
   , primary_keys as (${primaryKeysSql})
-  , relationships as (${relationshipsSql})
+  , relationships as (${relationshipsOldSql})
 select
   *
   ${includeColumns ? `, ${coalesceRowsToArray('columns', 'columns.table_id = tables.id')}` : ''}

--- a/src/lib/sql/index.ts
+++ b/src/lib/sql/index.ts
@@ -16,6 +16,7 @@ export const policiesSql = await readFile(join(__dirname, 'policies.sql'), 'utf-
 export const primaryKeysSql = await readFile(join(__dirname, 'primary_keys.sql'), 'utf-8')
 export const publicationsSql = await readFile(join(__dirname, 'publications.sql'), 'utf-8')
 export const relationshipsSql = await readFile(join(__dirname, 'relationships.sql'), 'utf-8')
+export const relationshipsOldSql = await readFile(join(__dirname, 'relationships_old.sql'), 'utf-8')
 export const rolesSql = await readFile(join(__dirname, 'roles.sql'), 'utf-8')
 export const schemasSql = await readFile(join(__dirname, 'schemas.sql'), 'utf-8')
 export const tablesSql = await readFile(join(__dirname, 'tables.sql'), 'utf-8')

--- a/src/lib/sql/relationships.sql
+++ b/src/lib/sql/relationships.sql
@@ -1,25 +1,44 @@
-SELECT
-  c.oid :: int8 AS id,
-  c.conname AS constraint_name,
-  nsa.nspname AS source_schema,
-  csa.relname AS source_table_name,
-  sa.attname AS source_column_name,
-  nta.nspname AS target_table_schema,
-  cta.relname AS target_table_name,
-  ta.attname AS target_column_name
-FROM
-  pg_constraint c
-  JOIN (
-    pg_attribute sa
-    JOIN pg_class csa ON sa.attrelid = csa.oid
-    JOIN pg_namespace nsa ON csa.relnamespace = nsa.oid
-  ) ON sa.attrelid = c.conrelid
-  AND sa.attnum = ANY (c.conkey)
-  JOIN (
-    pg_attribute ta
-    JOIN pg_class cta ON ta.attrelid = cta.oid
-    JOIN pg_namespace nta ON cta.relnamespace = nta.oid
-  ) ON ta.attrelid = c.confrelid
-  AND ta.attnum = ANY (c.confkey)
-WHERE
-  c.contype = 'f'
+-- Adapted from
+-- https://github.com/PostgREST/postgrest/blob/f9f0f79fa914ac00c11fbf7f4c558e14821e67e2/src/PostgREST/SchemaCache.hs#L722
+WITH
+    pks_uniques_cols AS (
+      SELECT
+        connamespace,
+        conrelid,
+        jsonb_agg(column_info.cols) as cols
+      FROM pg_constraint
+      JOIN lateral (
+        SELECT array_agg(cols.attname order by cols.attnum) as cols
+        FROM ( select unnest(conkey) as col) _
+        JOIN pg_attribute cols on cols.attrelid = conrelid and cols.attnum = col
+      ) column_info ON TRUE
+      WHERE
+        contype IN ('p', 'u') and
+        connamespace::regnamespace::text <> 'pg_catalog'
+      GROUP BY connamespace, conrelid
+    )
+    SELECT
+      traint.oid AS id,
+      traint.conname AS foreign_key_name,
+      ns1.nspname AS schema,
+      tab.relname AS relation,
+      column_info.cols AS columns,
+      ns2.nspname AS referenced_schema,
+      other.relname AS referenced_relation,
+      column_info.refs AS referenced_columns
+    FROM pg_constraint traint
+    JOIN LATERAL (
+      SELECT
+        array_agg(row(cols.attname, refs.attname) order by ord) AS cols_and_fcols,
+        jsonb_agg(cols.attname order by ord) AS cols,
+        jsonb_agg(refs.attname order by ord) AS refs
+      FROM unnest(traint.conkey, traint.confkey) WITH ORDINALITY AS _(col, ref, ord)
+      JOIN pg_attribute cols ON cols.attrelid = traint.conrelid AND cols.attnum = col
+      JOIN pg_attribute refs ON refs.attrelid = traint.confrelid AND refs.attnum = ref
+    ) AS column_info ON TRUE
+    JOIN pg_namespace ns1 ON ns1.oid = traint.connamespace
+    JOIN pg_class tab ON tab.oid = traint.conrelid
+    JOIN pg_class other ON other.oid = traint.confrelid
+    JOIN pg_namespace ns2 ON ns2.oid = other.relnamespace
+    LEFT JOIN pks_uniques_cols pks_uqs ON pks_uqs.connamespace = traint.connamespace AND pks_uqs.conrelid = traint.conrelid
+    WHERE traint.contype = 'f'

--- a/src/lib/sql/relationships.sql
+++ b/src/lib/sql/relationships.sql
@@ -1,44 +1,25 @@
 -- Adapted from
 -- https://github.com/PostgREST/postgrest/blob/f9f0f79fa914ac00c11fbf7f4c558e14821e67e2/src/PostgREST/SchemaCache.hs#L722
-WITH
-    pks_uniques_cols AS (
-      SELECT
-        connamespace,
-        conrelid,
-        jsonb_agg(column_info.cols) as cols
-      FROM pg_constraint
-      JOIN lateral (
-        SELECT array_agg(cols.attname order by cols.attnum) as cols
-        FROM ( select unnest(conkey) as col) _
-        JOIN pg_attribute cols on cols.attrelid = conrelid and cols.attnum = col
-      ) column_info ON TRUE
-      WHERE
-        contype IN ('p', 'u') and
-        connamespace::regnamespace::text <> 'pg_catalog'
-      GROUP BY connamespace, conrelid
-    )
-    SELECT
-      traint.oid AS id,
-      traint.conname AS foreign_key_name,
-      ns1.nspname AS schema,
-      tab.relname AS relation,
-      column_info.cols AS columns,
-      ns2.nspname AS referenced_schema,
-      other.relname AS referenced_relation,
-      column_info.refs AS referenced_columns
-    FROM pg_constraint traint
-    JOIN LATERAL (
-      SELECT
-        array_agg(row(cols.attname, refs.attname) order by ord) AS cols_and_fcols,
-        jsonb_agg(cols.attname order by ord) AS cols,
-        jsonb_agg(refs.attname order by ord) AS refs
-      FROM unnest(traint.conkey, traint.confkey) WITH ORDINALITY AS _(col, ref, ord)
-      JOIN pg_attribute cols ON cols.attrelid = traint.conrelid AND cols.attnum = col
-      JOIN pg_attribute refs ON refs.attrelid = traint.confrelid AND refs.attnum = ref
-    ) AS column_info ON TRUE
-    JOIN pg_namespace ns1 ON ns1.oid = traint.connamespace
-    JOIN pg_class tab ON tab.oid = traint.conrelid
-    JOIN pg_class other ON other.oid = traint.confrelid
-    JOIN pg_namespace ns2 ON ns2.oid = other.relnamespace
-    LEFT JOIN pks_uniques_cols pks_uqs ON pks_uqs.connamespace = traint.connamespace AND pks_uqs.conrelid = traint.conrelid
-    WHERE traint.contype = 'f'
+SELECT
+  traint.oid AS id,
+  traint.conname AS foreign_key_name,
+  ns1.nspname AS schema,
+  tab.relname AS relation,
+  column_info.cols AS columns,
+  ns2.nspname AS referenced_schema,
+  other.relname AS referenced_relation,
+  column_info.refs AS referenced_columns
+FROM pg_constraint traint
+JOIN LATERAL (
+  SELECT
+    jsonb_agg(cols.attname order by ord) AS cols,
+    jsonb_agg(refs.attname order by ord) AS refs
+  FROM unnest(traint.conkey, traint.confkey) WITH ORDINALITY AS _(col, ref, ord)
+  JOIN pg_attribute cols ON cols.attrelid = traint.conrelid AND cols.attnum = col
+  JOIN pg_attribute refs ON refs.attrelid = traint.confrelid AND refs.attnum = ref
+) AS column_info ON TRUE
+JOIN pg_namespace ns1 ON ns1.oid = traint.connamespace
+JOIN pg_class tab ON tab.oid = traint.conrelid
+JOIN pg_class other ON other.oid = traint.confrelid
+JOIN pg_namespace ns2 ON ns2.oid = other.relnamespace
+WHERE traint.contype = 'f'

--- a/src/lib/sql/relationships_old.sql
+++ b/src/lib/sql/relationships_old.sql
@@ -1,0 +1,25 @@
+SELECT
+  c.oid :: int8 AS id,
+  c.conname AS constraint_name,
+  nsa.nspname AS source_schema,
+  csa.relname AS source_table_name,
+  sa.attname AS source_column_name,
+  nta.nspname AS target_table_schema,
+  cta.relname AS target_table_name,
+  ta.attname AS target_column_name
+FROM
+  pg_constraint c
+  JOIN (
+    pg_attribute sa
+    JOIN pg_class csa ON sa.attrelid = csa.oid
+    JOIN pg_namespace nsa ON csa.relnamespace = nsa.oid
+  ) ON sa.attrelid = c.conrelid
+  AND sa.attnum = ANY (c.conkey)
+  JOIN (
+    pg_attribute ta
+    JOIN pg_class cta ON ta.attrelid = cta.oid
+    JOIN pg_namespace nta ON cta.relnamespace = nta.oid
+  ) ON ta.attrelid = c.confrelid
+  AND ta.attnum = ANY (c.confkey)
+WHERE
+  c.contype = 'f'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -186,7 +186,7 @@ export const postgresPublicationSchema = Type.Object({
 })
 export type PostgresPublication = Static<typeof postgresPublicationSchema>
 
-export const postgresRelationshipSchema = Type.Object({
+export const postgresRelationshipOldSchema = Type.Object({
   id: Type.Integer(),
   constraint_name: Type.String(),
   source_schema: Type.String(),
@@ -195,6 +195,16 @@ export const postgresRelationshipSchema = Type.Object({
   target_table_schema: Type.String(),
   target_table_name: Type.String(),
   target_column_name: Type.String(),
+})
+export const postgresRelationshipSchema = Type.Object({
+  id: Type.Integer(),
+  foreign_key_name: Type.String(),
+  schema: Type.String(),
+  relation: Type.String(),
+  columns: Type.Array(Type.String()),
+  referenced_schema: Type.String(),
+  referenced_relation: Type.String(),
+  referenced_columns: Type.Array(Type.String()),
 })
 export type PostgresRelationship = Static<typeof postgresRelationshipSchema>
 
@@ -296,7 +306,7 @@ export const postgresTableSchema = Type.Object({
   comment: Type.Union([Type.String(), Type.Null()]),
   columns: Type.Optional(Type.Array(postgresColumnSchema)),
   primary_keys: Type.Array(postgresPrimaryKeySchema),
-  relationships: Type.Array(postgresRelationshipSchema),
+  relationships: Type.Array(postgresRelationshipOldSchema),
 })
 export type PostgresTable = Static<typeof postgresTableSchema>
 

--- a/src/server/routes/generators/typescript.ts
+++ b/src/server/routes/generators/typescript.ts
@@ -24,6 +24,7 @@ export default async (fastify: FastifyInstance) => {
     const { data: views, error: viewsError } = await pgMeta.views.list()
     const { data: materializedViews, error: materializedViewsError } =
       await pgMeta.materializedViews.list({ includeColumns: true })
+    const { data: relationships, error: relationshipsError } = await pgMeta.relationships.list()
     const { data: functions, error: functionsError } = await pgMeta.functions.list()
     const { data: types, error: typesError } = await pgMeta.types.list({
       includeArrayTypes: true,
@@ -54,6 +55,11 @@ export default async (fastify: FastifyInstance) => {
       reply.code(500)
       return { error: materializedViewsError.message }
     }
+    if (relationshipsError) {
+      request.log.error({ error: relationshipsError, request: extractRequestForLogging(request) })
+      reply.code(500)
+      return { error: relationshipsError.message }
+    }
     if (functionsError) {
       request.log.error({ error: functionsError, request: extractRequestForLogging(request) })
       reply.code(500)
@@ -74,6 +80,7 @@ export default async (fastify: FastifyInstance) => {
       tables,
       views,
       materializedViews,
+      relationships,
       functions: functions.filter(
         ({ return_type }) => !['trigger', 'event_trigger'].includes(return_type)
       ),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -41,6 +41,7 @@ if (EXPORT_DOCS) {
   const { data: views, error: viewsError } = await pgMeta.views.list()
   const { data: materializedViews, error: materializedViewsError } =
     await pgMeta.materializedViews.list({ includeColumns: true })
+  const { data: relationships, error: relationshipsError } = await pgMeta.relationships.list()
   const { data: functions, error: functionsError } = await pgMeta.functions.list()
   const { data: types, error: typesError } = await pgMeta.types.list({
     includeArrayTypes: true,
@@ -60,6 +61,9 @@ if (EXPORT_DOCS) {
   if (materializedViewsError) {
     throw new Error(materializedViewsError.message)
   }
+  if (relationshipsError) {
+    throw new Error(relationshipsError.message)
+  }
   if (functionsError) {
     throw new Error(functionsError.message)
   }
@@ -77,6 +81,7 @@ if (EXPORT_DOCS) {
       tables,
       views,
       materializedViews,
+      relationships,
       functions: functions.filter(
         ({ return_type }) => !['trigger', 'event_trigger'].includes(return_type)
       ),

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -2,6 +2,7 @@ import prettier from 'prettier'
 import type {
   PostgresFunction,
   PostgresMaterializedView,
+  PostgresRelationship,
   PostgresSchema,
   PostgresTable,
   PostgresType,
@@ -13,6 +14,7 @@ export const apply = ({
   tables,
   views,
   materializedViews,
+  relationships,
   functions,
   types,
   arrayTypes,
@@ -21,6 +23,7 @@ export const apply = ({
   tables: (PostgresTable & { columns: unknown[] })[]
   views: (PostgresView & { columns: unknown[] })[]
   materializedViews: (PostgresMaterializedView & { columns: unknown[] })[]
+  relationships: PostgresRelationship[]
   functions: PostgresFunction[]
   types: PostgresType[]
   arrayTypes: PostgresType[]
@@ -145,6 +148,18 @@ export interface Database {
                         return output
                       })}
                   }
+                  Relationships: [
+                    ${relationships
+                      .filter((relationship) => relationship.schema === table.schema && relationship.relation === table.name)
+                      .map((relationship) => `{
+                        foreignKeyName: ${JSON.stringify(relationship.foreign_key_name)}
+                        columns: ${JSON.stringify(relationship.columns)}
+                        referencedSchema: ${JSON.stringify(relationship.referenced_schema)}
+                        referencedRelation: ${JSON.stringify(relationship.referenced_relation)}
+                        referencedColumns: ${JSON.stringify(relationship.referenced_columns)}
+                      }`)
+                    }
+                  ]
                 }`
                   )
             }

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -150,15 +150,20 @@ export interface Database {
                   }
                   Relationships: [
                     ${relationships
-                      .filter((relationship) => relationship.schema === table.schema && relationship.relation === table.name)
-                      .map((relationship) => `{
+                      .filter(
+                        (relationship) =>
+                          relationship.schema === table.schema &&
+                          relationship.relation === table.name
+                      )
+                      .map(
+                        (relationship) => `{
                         foreignKeyName: ${JSON.stringify(relationship.foreign_key_name)}
                         columns: ${JSON.stringify(relationship.columns)}
                         referencedSchema: ${JSON.stringify(relationship.referenced_schema)}
                         referencedRelation: ${JSON.stringify(relationship.referenced_relation)}
                         referencedColumns: ${JSON.stringify(relationship.referenced_columns)}
-                      }`)
-                    }
+                      }`
+                      )}
                   ]
                 }`
                   )

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -159,7 +159,6 @@ export interface Database {
                         (relationship) => `{
                         foreignKeyName: ${JSON.stringify(relationship.foreign_key_name)}
                         columns: ${JSON.stringify(relationship.columns)}
-                        referencedSchema: ${JSON.stringify(relationship.referenced_schema)}
                         referencedRelation: ${JSON.stringify(relationship.referenced_relation)}
                         referencedColumns: ${JSON.stringify(relationship.referenced_columns)}
                       }`

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -155,6 +155,9 @@ export interface Database {
                           relationship.schema === table.schema &&
                           relationship.relation === table.name
                       )
+                      .sort(({ foreign_key_name: a }, { foreign_key_name: b }) =>
+                        a.localeCompare(b)
+                      )
                       .map(
                         (relationship) => `{
                         foreignKeyName: ${JSON.stringify(relationship.foreign_key_name)}

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -30,6 +30,7 @@ test('typegen', async () => {
               id?: number
               name?: string
             }
+            Relationships: []
           }
           memes: {
             Row: {
@@ -56,6 +57,15 @@ test('typegen', async () => {
               name?: string
               status?: Database["public"]["Enums"]["meme_status"] | null
             }
+            Relationships: [
+              {
+                foreignKeyName: "memes_category_fkey"
+                columns: ["category"]
+                referencedSchema: "public"
+                referencedRelation: "category"
+                referencedColumns: ["id"]
+              }
+            ]
           }
           todos: {
             Row: {
@@ -74,6 +84,15 @@ test('typegen', async () => {
               id?: number
               "user-id"?: number
             }
+            Relationships: [
+              {
+                foreignKeyName: "todos_user-id_fkey"
+                columns: ["user-id"]
+                referencedSchema: "public"
+                referencedRelation: "users"
+                referencedColumns: ["id"]
+              }
+            ]
           }
           users: {
             Row: {
@@ -91,6 +110,7 @@ test('typegen', async () => {
               name?: string | null
               status?: Database["public"]["Enums"]["user_status"] | null
             }
+            Relationships: []
           }
           users_audit: {
             Row: {
@@ -111,6 +131,7 @@ test('typegen', async () => {
               previous_value?: Json | null
               user_id?: number | null
             }
+            Relationships: []
           }
         }
         Views: {

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -61,7 +61,6 @@ test('typegen', async () => {
               {
                 foreignKeyName: "memes_category_fkey"
                 columns: ["category"]
-                referencedSchema: "public"
                 referencedRelation: "category"
                 referencedColumns: ["id"]
               }
@@ -88,7 +87,6 @@ test('typegen', async () => {
               {
                 foreignKeyName: "todos_user-id_fkey"
                 columns: ["user-id"]
-                referencedSchema: "public"
                 referencedRelation: "users"
                 referencedColumns: ["id"]
               }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Include table relationships in typegen. This is a prerequisite for determining the cardinality of a relationship, which is necessary to resolve https://github.com/supabase/postgrest-js/issues/303.

An example is shown in the diff for test/server/typegen.ts.
