### PR TITLE
fix(typegen): omit `columns` when querying tables

### DIFF
--- a/src/server/routes/generators/typescript.ts
+++ b/src/server/routes/generators/typescript.ts
@@ -75,7 +75,7 @@ export default async (fastify: FastifyInstance) => {
       return { error: materializedViewsError.message }
     }
     if (columnsError) {
-      request.log.error({ error: columns, request: extractRequestForLogging(request) })
+      request.log.error({ error: columnsError, request: extractRequestForLogging(request) })
       reply.code(500)
       return { error: columnsError.message }
     }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -38,24 +38,29 @@ if (EXPORT_DOCS) {
   })
   const { data: schemas, error: schemasError } = await pgMeta.schemas.list()
   const { data: tables, error: tablesError } = await pgMeta.tables.list({
-    includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
+    includedSchemas:
+      GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
     includeColumns: false,
   })
   const { data: views, error: viewsError } = await pgMeta.views.list({
-    includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
+    includedSchemas:
+      GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
     includeColumns: false,
   })
   const { data: materializedViews, error: materializedViewsError } =
     await pgMeta.materializedViews.list({
-      includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
+      includedSchemas:
+        GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
       includeColumns: false,
     })
   const { data: columns, error: columnsError } = await pgMeta.columns.list({
-    includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
+    includedSchemas:
+      GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
   })
   const { data: relationships, error: relationshipsError } = await pgMeta.relationships.list()
   const { data: functions, error: functionsError } = await pgMeta.functions.list({
-    includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
+    includedSchemas:
+      GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
   })
   const { data: types, error: typesError } = await pgMeta.types.list({
     includeArrayTypes: true,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -37,12 +37,26 @@ if (EXPORT_DOCS) {
     connectionString: PG_CONNECTION,
   })
   const { data: schemas, error: schemasError } = await pgMeta.schemas.list()
-  const { data: tables, error: tablesError } = await pgMeta.tables.list()
-  const { data: views, error: viewsError } = await pgMeta.views.list()
+  const { data: tables, error: tablesError } = await pgMeta.tables.list({
+    includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
+    includeColumns: false,
+  })
+  const { data: views, error: viewsError } = await pgMeta.views.list({
+    includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
+    includeColumns: false,
+  })
   const { data: materializedViews, error: materializedViewsError } =
-    await pgMeta.materializedViews.list({ includeColumns: true })
+    await pgMeta.materializedViews.list({
+      includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
+      includeColumns: false,
+    })
+  const { data: columns, error: columnsError } = await pgMeta.columns.list({
+    includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
+  })
   const { data: relationships, error: relationshipsError } = await pgMeta.relationships.list()
-  const { data: functions, error: functionsError } = await pgMeta.functions.list()
+  const { data: functions, error: functionsError } = await pgMeta.functions.list({
+    includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS.length > 0 ? GENERATE_TYPES_INCLUDED_SCHEMAS : undefined,
+  })
   const { data: types, error: typesError } = await pgMeta.types.list({
     includeArrayTypes: true,
     includeSystemSchemas: true,
@@ -60,6 +74,9 @@ if (EXPORT_DOCS) {
   }
   if (materializedViewsError) {
     throw new Error(materializedViewsError.message)
+  }
+  if (columnsError) {
+    throw new Error(columnsError.message)
   }
   if (relationshipsError) {
     throw new Error(relationshipsError.message)
@@ -81,6 +98,7 @@ if (EXPORT_DOCS) {
       tables,
       views,
       materializedViews,
+      columns,
       relationships,
       functions: functions.filter(
         ({ return_type }) => !['trigger', 'event_trigger'].includes(return_type)


### PR DESCRIPTION
Or views etc. This can be expensive on a complex enough schema and can easily trip over the 15s timeout.

Instead, query all columns separately, which should hopefully be less taxing and easier to plan.

Also omit excluded schemas when listing tables/views/etc.

Benchmark results on 100 tables with 100 columns each:

Before:
```
  Time (mean ± σ):      8.134 s ±  0.211 s    [User: 0.094 s, System: 0.017 s]
  Range (min … max):    7.857 s …  8.569 s    10 runs
```

After:
```
  Time (mean ± σ):      1.787 s ±  0.113 s    [User: 0.094 s, System: 0.016 s]
  Range (min … max):    1.648 s …  1.980 s    10 runs
```