### PR TITLE
fix: make `Json` object values possibly `undefined`

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -40,7 +40,7 @@ export const apply = ({
     }, {} as Record<string, PostgresColumn[]>)
 
   let output = `
-export type Json = string | number | boolean | null | { [key: string]: Json } | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
 export interface Database {
   ${schemas

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -11,7 +11,7 @@ test('typegen', async () => {
       | number
       | boolean
       | null
-      | { [key: string]: Json }
+      | { [key: string]: Json | undefined }
       | Json[]
 
     export interface Database {


### PR DESCRIPTION
See also https://github.com/denoland/deno_std/pull/2565. Omitting `undefined` makes the `Json` type pretty annoying to use, e.g. when passing values to `jsonb` columns/params.
