### PR TITLE
fix: identifier double escaping

### DIFF
--- a/src/lib/PostgresMetaColumnPrivileges.ts
+++ b/src/lib/PostgresMetaColumnPrivileges.ts
@@ -69,7 +69,7 @@ where a.attrelid = ${literal(relationId)}
   and a.attnum = ${literal(columnNumber)}
 into col;
 execute format(
-  'grant ${privilege_type} (%I) on %I to ${
+  'grant ${privilege_type} (%I) on %s to ${
       grantee.toLowerCase() === 'public' ? 'public' : ident(grantee)
     } ${is_grantable ? 'with grant option' : ''}',
   col.attname,
@@ -113,7 +113,7 @@ where a.attrelid = ${literal(relationId)}
   and a.attnum = ${literal(columnNumber)}
 into col;
 execute format(
-  'revoke ${privilege_type} (%I) on %I from ${
+  'revoke ${privilege_type} (%I) on %s from ${
       grantee.toLowerCase() === 'public' ? 'public' : ident(grantee)
     }',
   col.attname,

--- a/src/lib/PostgresMetaTablePrivileges.ts
+++ b/src/lib/PostgresMetaTablePrivileges.ts
@@ -115,7 +115,7 @@ begin
 ${grants
   .map(
     ({ privilege_type, relation_id, grantee, is_grantable }) =>
-      `execute format('grant ${privilege_type} on table %I to ${
+      `execute format('grant ${privilege_type} on table %s to ${
         grantee.toLowerCase() === 'public' ? 'public' : ident(grantee)
       } ${is_grantable ? 'with grant option' : ''}', ${relation_id}::regclass);`
   )
@@ -147,7 +147,7 @@ begin
 ${revokes
   .map(
     (revoke) =>
-      `execute format('revoke ${revoke.privilege_type} on table %I from ${revoke.grantee}', ${revoke.relation_id}::regclass);`
+      `execute format('revoke ${revoke.privilege_type} on table %s from ${revoke.grantee}', ${revoke.relation_id}::regclass);`
   )
   .join('\n')}
 end $$;

--- a/test/server/column-privileges.ts
+++ b/test/server/column-privileges.ts
@@ -81,7 +81,7 @@ test('revoke & grant column privileges', async () => {
     ],
   })
   let privs = res.json<PostgresColumnPrivileges[]>()
-  expect(privs.length === 1)
+  expect(privs.length).toBe(1)
   expect(privs[0]).toMatchInlineSnapshot(
     { column_id: expect.stringMatching(/^\d+\.\d+$/) },
     `
@@ -156,7 +156,7 @@ test('revoke & grant column privileges', async () => {
     ],
   })
   privs = res.json<PostgresColumnPrivileges[]>()
-  expect(privs.length === 1)
+  expect(privs.length).toBe(1)
   expect(privs[0]).toMatchInlineSnapshot(
     { column_id: expect.stringMatching(/^\d+\.\d+$/) },
     `
@@ -200,6 +200,161 @@ test('revoke & grant column privileges', async () => {
     path: '/query',
     payload: {
       query: `drop role r;`,
+    },
+  })
+  if (res.json().error) {
+    throw new Error(res.payload)
+  }
+})
+
+test('revoke & grant column privileges w/ quoted column name', async () => {
+  let res = await app.inject({
+    method: 'POST',
+    path: '/query',
+    payload: {
+      query: `create role r; create table "t 1"("c 1" int8);`,
+    },
+  })
+  if (res.json().error) {
+    throw new Error(res.payload)
+  }
+
+  res = await app.inject({ method: 'GET', path: '/column-privileges' })
+  const { column_id } = res
+    .json<PostgresColumnPrivileges[]>()
+    .find(({ relation_name, column_name }) => relation_name === 't 1' && column_name === 'c 1')!
+
+  res = await app.inject({
+    method: 'POST',
+    path: '/column-privileges',
+    payload: [
+      {
+        column_id,
+        grantee: 'r',
+        privilege_type: 'ALL',
+      },
+    ],
+  })
+  let privs = res.json<PostgresColumnPrivileges[]>()
+  expect(privs.length).toBe(1)
+  expect(privs[0]).toMatchInlineSnapshot(
+    { column_id: expect.stringMatching(/^\d+\.\d+$/) },
+    `
+    {
+      "column_id": StringMatching /\\^\\\\d\\+\\\\\\.\\\\d\\+\\$/,
+      "column_name": "c 1",
+      "privileges": [
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "UPDATE",
+        },
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "SELECT",
+        },
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "REFERENCES",
+        },
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "INSERT",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "UPDATE",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "SELECT",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "REFERENCES",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "INSERT",
+        },
+      ],
+      "relation_name": "t 1",
+      "relation_schema": "public",
+    }
+  `
+  )
+
+  res = await app.inject({
+    method: 'DELETE',
+    path: '/column-privileges',
+    payload: [
+      {
+        column_id,
+        grantee: 'r',
+        privilege_type: 'ALL',
+      },
+    ],
+  })
+  privs = res.json<PostgresColumnPrivileges[]>()
+  expect(privs.length).toBe(1)
+  expect(privs[0]).toMatchInlineSnapshot(
+    { column_id: expect.stringMatching(/^\d+\.\d+$/) },
+    `
+    {
+      "column_id": StringMatching /\\^\\\\d\\+\\\\\\.\\\\d\\+\\$/,
+      "column_name": "c 1",
+      "privileges": [
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "UPDATE",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "SELECT",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "REFERENCES",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "INSERT",
+        },
+      ],
+      "relation_name": "t 1",
+      "relation_schema": "public",
+    }
+  `
+  )
+
+  res = await app.inject({
+    method: 'POST',
+    path: '/query',
+    payload: {
+      query: `drop role r; drop table "t 1";`,
     },
   })
   if (res.json().error) {

--- a/test/server/table-privileges.ts
+++ b/test/server/table-privileges.ts
@@ -82,7 +82,7 @@ test('revoke & grant table privileges', async () => {
     ],
   })
   let privs = res.json<PostgresTablePrivileges[]>()
-  expect(privs.length === 1)
+  expect(privs.length).toBe(1)
   expect(privs[0]).toMatchInlineSnapshot(
     { relation_id: expect.any(Number) },
     `
@@ -108,7 +108,7 @@ test('revoke & grant table privileges', async () => {
     ],
   })
   privs = res.json<PostgresTablePrivileges[]>()
-  expect(privs.length === 1)
+  expect(privs.length).toBe(1)
   expect(privs[0]).toMatchInlineSnapshot(
     { relation_id: expect.any(Number) },
     `
@@ -164,4 +164,213 @@ test('revoke & grant table privileges', async () => {
     }
   `
   )
+})
+
+test('revoke & grant table privileges w/ quoted table name', async () => {
+  let res = await app.inject({
+    method: 'POST',
+    path: '/query',
+    payload: {
+      query: `create role r; create schema "s 1"; create table "s 1"."t 1"();`,
+    },
+  })
+  if (res.json().error) {
+    throw new Error(res.payload)
+  }
+
+  res = await app.inject({ method: 'GET', path: '/table-privileges' })
+  const { relation_id } = res
+    .json<PostgresTablePrivileges[]>()
+    .find(({ schema, name }) => schema === 's 1' && name === 't 1')!
+
+  res = await app.inject({
+    method: 'POST',
+    path: '/table-privileges',
+    payload: [
+      {
+        relation_id,
+        grantee: 'r',
+        privilege_type: 'ALL',
+      },
+    ],
+  })
+  let privs = res.json<PostgresTablePrivileges[]>()
+  expect(privs.length).toBe(1)
+  expect(privs[0]).toMatchInlineSnapshot(
+    { relation_id: expect.any(Number) },
+    `
+    {
+      "kind": "table",
+      "name": "t 1",
+      "privileges": [
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "TRIGGER",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "REFERENCES",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "TRUNCATE",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "DELETE",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "UPDATE",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "SELECT",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "INSERT",
+        },
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "TRIGGER",
+        },
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "REFERENCES",
+        },
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "TRUNCATE",
+        },
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "DELETE",
+        },
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "UPDATE",
+        },
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "SELECT",
+        },
+        {
+          "grantee": "r",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "INSERT",
+        },
+      ],
+      "relation_id": Any<Number>,
+      "schema": "s 1",
+    }
+  `
+  )
+
+  res = await app.inject({
+    method: 'DELETE',
+    path: '/table-privileges',
+    payload: [
+      {
+        relation_id,
+        grantee: 'r',
+        privilege_type: 'ALL',
+      },
+    ],
+  })
+  privs = res.json<PostgresTablePrivileges[]>()
+  expect(privs.length).toBe(1)
+  expect(privs[0]).toMatchInlineSnapshot(
+    { relation_id: expect.any(Number) },
+    `
+    {
+      "kind": "table",
+      "name": "t 1",
+      "privileges": [
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "TRIGGER",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "REFERENCES",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "TRUNCATE",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "DELETE",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "UPDATE",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "SELECT",
+        },
+        {
+          "grantee": "postgres",
+          "grantor": "postgres",
+          "is_grantable": false,
+          "privilege_type": "INSERT",
+        },
+      ],
+      "relation_id": Any<Number>,
+      "schema": "s 1",
+    }
+  `
+  )
+
+  res = await app.inject({
+    method: 'POST',
+    path: '/query',
+    payload: {
+      query: `drop role r; drop schema "s 1" cascade;`,
+    },
+  })
+  if (res.json().error) {
+    throw new Error(res.payload)
+  }
 })


### PR DESCRIPTION
`::regclass` already escapes identifier names, no need to `%I` it. E.g. `auth.users` would be double-escaped into `"auth.users"` instead of `"auth"."users"`