### PR TITLE
fix: duplicate columns on cols w/ multiple checks

### DIFF
--- a/src/lib/sql/columns.sql
+++ b/src/lib/sql/columns.sql
@@ -83,7 +83,8 @@ FROM
     WHERE contype = 'u' AND cardinality(conkey) = 1
   ) AS uniques ON uniques.table_id = c.oid AND uniques.ordinal_position = a.attnum
   LEFT JOIN (
-    SELECT
+    -- We only select the first column check
+    SELECT DISTINCT ON (table_id, ordinal_position)
       conrelid AS table_id,
       conkey[1] AS ordinal_position,
       substring(
@@ -93,7 +94,7 @@ FROM
       ) AS "definition"
     FROM pg_constraint
     WHERE contype = 'c' AND cardinality(conkey) = 1
-    ORDER BY oid asc
+    ORDER BY table_id, ordinal_position, oid asc
   ) AS check_constraints ON check_constraints.table_id = c.oid AND check_constraints.ordinal_position = a.attnum
 WHERE
   NOT pg_is_other_temp_schema(nc.oid)

--- a/test/lib/columns.ts
+++ b/test/lib/columns.ts
@@ -899,3 +899,36 @@ create table public.t (
 
   await pgMeta.query(`drop table public.t;`)
 })
+
+test('column with multiple checks', async () => {
+  await pgMeta.query(`create table t(c int8 check (c != 0) check (c != -1))`)
+
+  const res = await pgMeta.columns.list()
+  const columns = res.data
+    ?.filter((c) => c.schema === 'public' && c.table === 't')
+    .map(({ id, table_id, ...c }) => c)
+  expect(columns).toMatchInlineSnapshot(`
+    [
+      {
+        "check": "c <> 0",
+        "comment": null,
+        "data_type": "bigint",
+        "default_value": null,
+        "enums": [],
+        "format": "int8",
+        "identity_generation": null,
+        "is_generated": false,
+        "is_identity": false,
+        "is_nullable": true,
+        "is_unique": false,
+        "is_updatable": true,
+        "name": "c",
+        "ordinal_position": 1,
+        "schema": "public",
+        "table": "t",
+      },
+    ]
+  `)
+
+  await pgMeta.query(`drop table t`)
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Having multiple checks on a column results in `/columns` returning duplicate columns: https://github.com/supabase/supabase/issues/13970

## What is the new behavior?

Only select one column check
