### PR TITLE
feat: allow setting ssl root cert directly

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto'
+import { PoolConfig } from 'pg'
 import { getSecret } from '../lib/secrets.js'
 
 export const PG_META_HOST = process.env.PG_META_HOST || '0.0.0.0'
@@ -10,7 +12,6 @@ const PG_META_DB_USER = process.env.PG_META_DB_USER || 'postgres'
 const PG_META_DB_PORT = process.env.PG_META_DB_PORT || '5432'
 const PG_META_DB_PASSWORD = (await getSecret('PG_META_DB_PASSWORD')) || 'postgres'
 const PG_META_DB_SSL_MODE = process.env.PG_META_DB_SSL_MODE || 'disable'
-const PG_META_DB_SSL_ROOT_CERT_PATH = process.env.PG_META_DB_SSL_ROOT_CERT_PATH
 
 const PG_CONN_TIMEOUT_SECS = Number(process.env.PG_CONN_TIMEOUT_SECS || 15)
 
@@ -23,10 +24,13 @@ if (!PG_CONNECTION) {
   pgConn.password = PG_META_DB_PASSWORD
   pgConn.pathname = encodeURIComponent(PG_META_DB_NAME)
   pgConn.searchParams.set('sslmode', PG_META_DB_SSL_MODE)
-  if (PG_META_DB_SSL_ROOT_CERT_PATH) {
-    pgConn.searchParams.set('sslrootcert', PG_META_DB_SSL_ROOT_CERT_PATH)
-  }
   PG_CONNECTION = `${pgConn}`
+}
+
+export const PG_META_DB_SSL_ROOT_CERT = process.env.PG_META_DB_SSL_ROOT_CERT
+if (PG_META_DB_SSL_ROOT_CERT) {
+  // validate cert
+  new crypto.X509Certificate(PG_META_DB_SSL_ROOT_CERT)
 }
 
 export const EXPORT_DOCS = process.argv[2] === 'docs' && process.argv[3] === 'export'
@@ -35,5 +39,9 @@ export const GENERATE_TYPES =
 export const GENERATE_TYPES_INCLUDED_SCHEMAS =
   GENERATE_TYPES && process.argv[5] === '--include-schemas' ? process.argv[6]?.split(',') ?? [] : []
 
-export const DEFAULT_POOL_CONFIG = { max: 1, connectionTimeoutMillis: PG_CONN_TIMEOUT_SECS * 1000 }
+export const DEFAULT_POOL_CONFIG: PoolConfig = {
+  max: 1,
+  connectionTimeoutMillis: PG_CONN_TIMEOUT_SECS * 1000,
+}
+
 export const PG_META_REQ_HEADER = process.env.PG_META_REQ_HEADER || 'request-id'

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -42,6 +42,7 @@ export const GENERATE_TYPES_INCLUDED_SCHEMAS =
 export const DEFAULT_POOL_CONFIG: PoolConfig = {
   max: 1,
   connectionTimeoutMillis: PG_CONN_TIMEOUT_SECS * 1000,
+  ssl: PG_META_DB_SSL_ROOT_CERT ? { ca: PG_META_DB_SSL_ROOT_CERT } : undefined,
 }
 
 export const PG_META_REQ_HEADER = process.env.PG_META_REQ_HEADER || 'request-id'

--- a/test/server/ssl.ts
+++ b/test/server/ssl.ts
@@ -1,12 +1,14 @@
 import CryptoJS from 'crypto-js'
+import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { app } from './utils'
-import { CRYPTO_KEY } from '../../src/server/constants'
+import { CRYPTO_KEY, DEFAULT_POOL_CONFIG } from '../../src/server/constants'
 
 // @ts-ignore: Harmless type error on import.meta.
 const cwd = path.dirname(fileURLToPath(import.meta.url))
-const SSL_ROOT_CERT_PATH = path.join(cwd, '../db/server.crt')
+const sslRootCertPath = path.join(cwd, '../db/server.crt')
+const sslRootCert = fs.readFileSync(sslRootCertPath, { encoding: 'utf8' })
 
 test('query with no ssl', async () => {
   const res = await app.inject({
@@ -45,12 +47,15 @@ test('query with ssl w/o root cert', async () => {
 })
 
 test('query with ssl with root cert', async () => {
+  const defaultSsl = DEFAULT_POOL_CONFIG.ssl
+  DEFAULT_POOL_CONFIG.ssl = { ca: sslRootCert }
+
   const res = await app.inject({
     method: 'POST',
     path: '/query',
     headers: {
       'x-connection-encrypted': CryptoJS.AES.encrypt(
-        `postgresql://postgres:postgres@localhost:5432/postgres?sslmode=verify-full&sslrootcert=${SSL_ROOT_CERT_PATH}`,
+        `postgresql://postgres:postgres@localhost:5432/postgres?sslmode=verify-full`,
         CRYPTO_KEY
       ).toString(),
     },
@@ -63,4 +68,6 @@ test('query with ssl with root cert', async () => {
       },
     ]
   `)
+
+  DEFAULT_POOL_CONFIG.ssl = defaultSsl
 })


### PR DESCRIPTION
Set the root cert directly via env instead of setting the path of the cert. Also, `PG_META_DB_SSL_ROOT_CERT` will be applied on all pg connections, instead of the user having to set `&sslrootcert=` path in the connection string.

Follow up to https://github.com/supabase/postgres-meta/pull/600