### PR TITLE
fix(typegen): allow composite type attributes to be null

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -387,7 +387,7 @@ export interface Database {
                               type.name,
                               types,
                               schemas
-                            )}`
+                            )} | null`
                           }
                           return `${JSON.stringify(name)}: unknown`
                         })}

--- a/test/db/01-memes.sql
+++ b/test/db/01-memes.sql
@@ -1,8 +1,10 @@
 
+CREATE TYPE public.composite_t AS (attr int);
 
 CREATE TABLE public.category (
 	id serial NOT NULL PRIMARY KEY,
-	name text NOT NULL
+	name text NOT NULL,
+        composite composite_t
 );
 
 -- Fake policies

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -19,14 +19,17 @@ test('typegen', async () => {
         Tables: {
           category: {
             Row: {
+              composite: Database["public"]["CompositeTypes"]["composite_t"] | null
               id: number
               name: string
             }
             Insert: {
+              composite?: Database["public"]["CompositeTypes"]["composite_t"] | null
               id?: number
               name: string
             }
             Update: {
+              composite?: Database["public"]["CompositeTypes"]["composite_t"] | null
               id?: number
               name?: string
             }
@@ -264,7 +267,9 @@ test('typegen', async () => {
           user_status: "ACTIVE" | "INACTIVE"
         }
         CompositeTypes: {
-          [_ in never]: never
+          composite_t: {
+            attr: number | null
+          }
         }
       }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Typescript typegen bug fix

## What is the current behavior?

[CompositeTypes do not allow null values](https://github.com/supabase/supabase/issues/17539)

## What is the new behavior?

Generated composite types have nullable attributes.

