### PR TITLE
fix: use base/composite/enum type for fn columns

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -99,14 +99,14 @@ export interface Database {
                       ),
                       ...schemaFunctions
                         .filter((fn) => fn.argument_types === table.name)
-                        .map(
-                          (fn) =>
-                            `${JSON.stringify(fn.name)}: ${pgTypeToTsType(
-                              fn.return_type,
-                              types,
-                              schemas
-                            )} | null`
-                        ),
+                        .map((fn) => {
+                          const type = types.find(({ id }) => id === fn.return_type_id)
+                          let tsType = 'unknown'
+                          if (type) {
+                            tsType = pgTypeToTsType(type.name, types, schemas)
+                          }
+                          return `${JSON.stringify(fn.name)}: ${tsType} | null`
+                        }),
                     ]}
                   }
                   Insert: {

--- a/test/db/00-init.sql
+++ b/test/db/00-init.sql
@@ -61,6 +61,21 @@ $$
 select substring($1.details, 1, 3);
 $$ language sql stable;
 
+create function public.blurb_varchar(public.todos) returns character varying as
+$$
+select substring($1.details, 1, 3);
+$$ language sql stable;
+
+create function public.details_length(public.todos) returns integer as
+$$
+select length($1.details);
+$$ language sql stable;
+
+create function public.details_is_long(public.todos) returns boolean as
+$$
+select $1.details_length > 20;
+$$ language sql stable;
+
 create extension postgres_fdw;
 create server foreign_server foreign data wrapper postgres_fdw options (host 'localhost', port '5432', dbname 'postgres');
 create user mapping for postgres server foreign_server options (user 'postgres', password 'postgres');

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -72,6 +72,9 @@ test('typegen', async () => {
               id: number
               "user-id": number
               blurb: string | null
+              blurb_varchar: string | null
+              details_is_long: boolean | null
+              details_length: number | null
             }
             Insert: {
               details?: string | null
@@ -216,6 +219,24 @@ test('typegen', async () => {
               "": unknown
             }
             Returns: string
+          }
+          blurb_varchar: {
+            Args: {
+              "": unknown
+            }
+            Returns: string
+          }
+          details_is_long: {
+            Args: {
+              "": unknown
+            }
+            Returns: boolean
+          }
+          details_length: {
+            Args: {
+              "": unknown
+            }
+            Returns: number
           }
           function_returning_row: {
             Args: Record<PropertyKey, never>


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR changes `gen:types:typescript` to generate types for [function columns](https://github.com/supabase/postgres-meta/blob/master/src/server/templates/typescript.ts#L100-L109) instead of `unknown`.

## What is the current behavior?

The current output is,
```
// todos
Row: {
    details: string | null
    id: number
    "user-id": number
    blurb: string | null
    blurb_varchar: unknown | null
    details_is_long: unknown | null
    details_length: unknown | null
}
```
## What is the new behavior?

```
// todos
Row: {
    details: string | null
    id: number
    "user-id": number
    blurb: string | null
    blurb_varchar: string | null
    details_is_long: boolean | null
    details_length: number | null
}
```