### PR TITLE
fix(typegen): sort polymorphic function variants

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -357,6 +357,8 @@ export interface Database {
                   })()})${is_set_returning_function ? '[]' : ''}
                 }`
                     )
+                    // We only sorted by name on schemaFunctions - here we sort by arg names, arg types, and return type.
+                    .sort()
                     .join('|')}`
               )
             })()}

--- a/test/db/00-init.sql
+++ b/test/db/00-init.sql
@@ -93,3 +93,6 @@ stable
 as $$
   select id, name from public.users;
 $$;
+
+create or replace function public.polymorphic_function(text) returns void language sql as '';
+create or replace function public.polymorphic_function(bool) returns void language sql as '';

--- a/test/server/column-privileges.ts
+++ b/test/server/column-privileges.ts
@@ -3,14 +3,15 @@ import { app } from './utils'
 
 test('list column privileges', async () => {
   const res = await app.inject({ method: 'GET', path: '/column-privileges' })
-  expect(
-    res
-      .json<PostgresColumnPrivileges[]>()
-      .find(
-        ({ relation_schema, relation_name, column_name }) =>
-          relation_schema === 'public' && relation_name === 'todos' && column_name === 'id'
-      )
-  ).toMatchInlineSnapshot(
+  const column = res
+    .json<PostgresColumnPrivileges[]>()
+    .find(
+      ({ relation_schema, relation_name, column_name }) =>
+        relation_schema === 'public' && relation_name === 'todos' && column_name === 'id'
+    )!
+  // We don't guarantee order of privileges, but we want to keep the snapshots consistent.
+  column.privileges.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+  expect(column).toMatchInlineSnapshot(
     { column_id: expect.stringMatching(/^\d+\.\d+$/) },
     `
     {

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -240,6 +240,19 @@ test('typegen', async () => {
               name: string
             }[]
           }
+          polymorphic_function:
+            | {
+                Args: {
+                  "": boolean
+                }
+                Returns: undefined
+              }
+            | {
+                Args: {
+                  "": string
+                }
+                Returns: undefined
+              }
           postgres_fdw_disconnect: {
             Args: {
               "": string


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Function variants aren't sorted by args & return type https://github.com/supabase/cli/issues/1165

## What is the new behavior?

Sort 'em