### PR TITLE
fix(typegen): sort relationships by (fkey name, referenced table)

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -160,8 +160,10 @@ export interface Database {
                           relationship.schema === table.schema &&
                           relationship.relation === table.name
                       )
-                      .sort(({ foreign_key_name: a }, { foreign_key_name: b }) =>
-                        a.localeCompare(b)
+                      .sort(
+                        (a, b) =>
+                          a.foreign_key_name.localeCompare(b.foreign_key_name) ||
+                          a.referenced_relation.localeCompare(b.referenced_relation)
                       )
                       .map(
                         (relationship) => `{

--- a/test/db/00-init.sql
+++ b/test/db/00-init.sql
@@ -101,3 +101,5 @@ create table user_details (
   user_id int8 references users(id) primary key,
   details text
 );
+
+create view a_view as select id from users;

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -89,6 +89,13 @@ test('typegen', async () => {
                 foreignKeyName: "todos_user-id_fkey"
                 columns: ["user-id"]
                 isOneToOne: false
+                referencedRelation: "a_view"
+                referencedColumns: ["id"]
+              },
+              {
+                foreignKeyName: "todos_user-id_fkey"
+                columns: ["user-id"]
+                isOneToOne: false
                 referencedRelation: "users"
                 referencedColumns: ["id"]
               },
@@ -115,6 +122,13 @@ test('typegen', async () => {
               user_id?: number
             }
             Relationships: [
+              {
+                foreignKeyName: "user_details_user_id_fkey"
+                columns: ["user_id"]
+                isOneToOne: true
+                referencedRelation: "a_view"
+                referencedColumns: ["id"]
+              },
               {
                 foreignKeyName: "user_details_user_id_fkey"
                 columns: ["user_id"]
@@ -172,6 +186,18 @@ test('typegen', async () => {
           }
         }
         Views: {
+          a_view: {
+            Row: {
+              id: number | null
+            }
+            Insert: {
+              id?: number | null
+            }
+            Update: {
+              id?: number | null
+            }
+            Relationships: []
+          }
           todos_matview: {
             Row: {
               details: string | null
@@ -184,6 +210,13 @@ test('typegen', async () => {
                 columns: ["user-id"]
                 isOneToOne: false
                 referencedRelation: "users"
+                referencedColumns: ["id"]
+              },
+              {
+                foreignKeyName: "todos_user-id_fkey"
+                columns: ["user-id"]
+                isOneToOne: false
+                referencedRelation: "a_view"
                 referencedColumns: ["id"]
               },
               {
@@ -217,6 +250,13 @@ test('typegen', async () => {
                 columns: ["user-id"]
                 isOneToOne: false
                 referencedRelation: "users"
+                referencedColumns: ["id"]
+              },
+              {
+                foreignKeyName: "todos_user-id_fkey"
+                columns: ["user-id"]
+                isOneToOne: false
+                referencedRelation: "a_view"
                 referencedColumns: ["id"]
               },
               {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Generated relationships with the same `foreignKeyName` aren't sorted by `referencedRelation`

## What is the new behavior?

Sort by `(foreignKeyName, referencedRelation)`

## Additional context

https://github.com/supabase/cli/issues/1165
