### PR TITLE
fix: add integer to the list of numeric types

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -428,7 +428,7 @@ const pgTypeToTsType = (
 ): string => {
   if (pgType === 'bool') {
     return 'boolean'
-  } else if (['int2', 'int4', 'int8', 'float4', 'float8', 'numeric'].includes(pgType)) {
+  } else if (['int2', 'int4', 'int8', 'float4', 'float8', 'numeric', 'integer'].includes(pgType)) {
     return 'number'
   } else if (
     [


### PR DESCRIPTION
## What kind of change does this PR introduce?

bug fix

## What is the current behavior?

the return type `integer` of a function is `unknown`

## What is the new behavior?

`integer` is correctly parsed as `number`
