### PR TITLE
change(typegen: TS): Export type, not interface

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -44,7 +44,7 @@ export const apply = ({
   let output = `
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
-export interface Database {
+export type Database = {
   ${schemas
     .sort(({ name: a }, { name: b }) => a.localeCompare(b))
     .map((schema) => {

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -11,7 +11,7 @@ test('typegen', async () => {
       | { [key: string]: Json | undefined }
       | Json[]
 
-    export interface Database {
+    export type Database = {
       public: {
         Tables: {
           category: {
@@ -462,7 +462,7 @@ test('typegen w/ one-to-one relationships', async () => {
       | { [key: string]: Json | undefined }
       | Json[]
 
-    export interface Database {
+    export type Database = {
       public: {
         Tables: {
           category: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor change

## What is the current behavior?

Currently, the TypeScript type generation exports the `Database` type as an `interface`. However, this is somewhat problematic in that TypeScript `interface`s don't implicitly define an index signature for their keys.

### What do I mean by this?

Consider the following example:

```ts
type Pokemon = {
  name: string
  type: string | [string, string]
}

type Pokedex = Record<string, Pokemon>

interface MyPokedex {  // Note: interface!
  bulbasaur: Pokemon
  charmander: Pokemon
  squirtle: Pokemon
}

function getPokemon<T extends Pokedex>(pokedex: T): (keyof T)[] {
  return Object.keys(pokedex)
}
```

I would expect to be able to call `getPokemon` with `MyPokedex` as the type parameter. However, this results in a type error:

```text
Type 'MyPokedex' does not satisfy the constraint 'Pokedex'.
Index signature for type 'string' is missing in type 'MyPokedex'.
```

### What's the problem?

This means that if a library author wants to create a generic function where the expected type parameter is the user's `Database` type, there's no way for them to create a constraint.

For example, [isaacharrisholt/supawright](https://github.com/isaacharrisholt/supawright) uses the user's `Database` to accurately type input and output types for some of its functions (much like `supabase-js`). It uses the following code to constrain the type parameter passed into the `withSupawright` function:

```ts
import type { GenericSchema } from '@supabase/supabase-js/dist/module/lib/types'

export type GenericDatabase = Record<string, GenericSchema>
```

(yes, I'm stealing from Supabase, but it works)

However, if I try to have `withSupawright<Database extends GenericDatabase>()` and then call it with the exported `Database` interface, I get the error mentioned above:

```text
Type 'Database' does not satisfy the constraint 'GenericDatabase'.
Index signature for type 'string' is missing in type 'Database'.
```

Changing the exported `interface` to instead be a `type` resolves this.

We've been running the following...

```make
types:
    pnpm supabase gen types typescript --local | \
    sed 's/export interface Database {/export type Database = {/' \
    > src/types/database.ts
```

...in production for a while now, and it has no negative impact on the Supabase client, and doing `SupabaseClient<Database>` still works as expected.

It would make Supabase extension libraries like this one much easier to write, and I can't _think_ of any downsides to this change.

I might be missing something huge, in which case, let me know.

## What is the new behavior?

The TypeScript type generator returns a `type`, not an `interface`.
