### PR TITLE
fix: add ca-certificates to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ COPY . .
 RUN npm run build && npm prune --omit=dev
 
 FROM node:20-slim
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /usr/src/app
 COPY --from=build /usr/src/app/node_modules node_modules
 COPY --from=build /usr/src/app/dist dist


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/postgres-meta/issues/719

## What is the current behavior?

When using `sslmode=prefer` on a database that enforces ssl, node-postgres throws an error about self-signed certificate.

```
$ supabase gen types typescript --db-url 'postgres://aws-0-ap-southeast-1.pooler.supabase.com:5432/postgres'
Connecting to aws-0-ap-southeast-1.pooler.supabase.com
(node:1) ExperimentalWarning: Import assertions are not a stable feature of the JavaScript language. Avoid relying on their current behavior and syntax as those might change in a future version of Node.js.
(Use `node --trace-warnings ...` to show where the warning was created)
(node:1) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
file:///usr/src/app/dist/server/server.js:57
        throw new Error(schemasError.message);
              ^

Error: self-signed certificate in certificate chain
    at file:///usr/src/app/dist/server/server.js:57:15
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v18.18.2
error running container: exit 1
Try rerunning the command with --debug to troubleshoot the error.
exit status 1
```

This error is misleading because we don't use self-signed cert on hosted projects. The root cause is missing ca-certificates package in the docker image.

## What is the new behavior?

Installs the ca-certificates package so that typegen works correctly on projects that enforce ssl.

## Additional context

Add any other context or screenshots.
