### PR TITLE
fix(typegen): handle tables without any columns

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -33,16 +33,13 @@ export const apply = async ({
   arrayTypes: PostgresType[]
   detectOneToOneRelationships: boolean
 }): Promise<string> => {
-  const columnsByTableId = columns
+  const columnsByTableId = Object.fromEntries<PostgresColumn[]>(
+    [...tables, ...views, ...materializedViews].map((t) => [t.id, []])
+  )
+  columns
+    .filter((c) => c.table_id in columnsByTableId)
     .sort(({ name: a }, { name: b }) => a.localeCompare(b))
-    .reduce(
-      (acc, curr) => {
-        acc[curr.table_id] ??= []
-        acc[curr.table_id].push(curr)
-        return acc
-      },
-      {} as Record<string, PostgresColumn[]>
-    )
+    .forEach((c) => columnsByTableId[c.table_id].push(c))
 
   let output = `
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]

--- a/test/db/00-init.sql
+++ b/test/db/00-init.sql
@@ -118,3 +118,5 @@ create table user_details (
 );
 
 create view a_view as select id from users;
+
+create table empty();

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -30,6 +30,12 @@ test('typegen', async () => {
             }
             Relationships: []
           }
+          empty: {
+            Row: {}
+            Insert: {}
+            Update: {}
+            Relationships: []
+          }
           memes: {
             Row: {
               category: number | null
@@ -481,6 +487,12 @@ test('typegen w/ one-to-one relationships', async () => {
               id?: number
               name?: string
             }
+            Relationships: []
+          }
+          empty: {
+            Row: {}
+            Insert: {}
+            Update: {}
             Relationships: []
           }
           memes: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/postgres-meta/issues/726

## What is the new behavior?

Generating types for `create table empty()` should not crash.

## Additional context

Add any other context or screenshots.
