### PR TITLE
feat: implement graceful shutdown on sigterm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=build /usr/src/app/node_modules node_modules
 COPY --from=build /usr/src/app/dist dist
 COPY package.json ./
 ENV PG_META_PORT=8080
-CMD ["npm", "run", "start"]
+CMD ["node", "dist/server/server.js"]
 EXPOSE 8080
 # --start-period defaults to 0s, but can't be set to 0s (to be explicit) by now
 HEALTHCHECK --interval=5s --timeout=5s --retries=3 CMD node -e "fetch('http://localhost:8080/health').then((r) => {if (r.status !== 200) throw new Error(r.status)})"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY --from=build /usr/src/app/node_modules node_modules
 COPY --from=build /usr/src/app/dist dist
 COPY package.json ./
 ENV PG_META_PORT=8080
+# `npm run start` does not forward signals to child process
 CMD ["node", "dist/server/server.js"]
 EXPOSE 8080
 # --start-period defaults to 0s, but can't be set to 0s (to be explicit) by now

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fastify/swagger": "^8.2.1",
         "@fastify/type-provider-typebox": "^3.5.0",
         "@sinclair/typebox": "^0.31.25",
+        "close-with-grace": "^1.3.0",
         "crypto-js": "^4.0.0",
         "fastify": "^4.24.3",
         "fastify-metrics": "^10.0.0",
@@ -1586,6 +1587,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/close-with-grace": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/close-with-grace/-/close-with-grace-1.3.0.tgz",
+      "integrity": "sha512-lvm0rmLIR5bNz4CRKW6YvCfn9Wg5Wb9A8PJ3Bb+hjyikgC1RO1W3J4z9rBXQYw97mAte7dNSQI8BmUsxdlXQyw=="
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -6925,6 +6931,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+    },
+    "close-with-grace": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/close-with-grace/-/close-with-grace-1.3.0.tgz",
+      "integrity": "sha512-lvm0rmLIR5bNz4CRKW6YvCfn9Wg5Wb9A8PJ3Bb+hjyikgC1RO1W3J4z9rBXQYw97mAte7dNSQI8BmUsxdlXQyw=="
     },
     "color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@fastify/swagger": "^8.2.1",
     "@fastify/type-provider-typebox": "^3.5.0",
     "@sinclair/typebox": "^0.31.25",
+    "close-with-grace": "^1.3.0",
     "crypto-js": "^4.0.0",
     "fastify": "^4.24.3",
     "fastify-metrics": "^10.0.0",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -126,13 +126,13 @@ if (EXPORT_DOCS) {
     })
   )
 } else {
-  const closeListeners = closeWithGrace(async ({ signal, err, manual }) => {
+  const closeListeners = closeWithGrace(async ({ err }) => {
     if (err) {
       app.log.error(err)
     }
     await app.close()
   })
-  app.addHook('onClose', async (instance) => {
+  app.addHook('onClose', async () => {
     closeListeners.uninstall()
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix https://github.com/supabase/postgres-meta/issues/663

## What is the new behavior?

Uses [closes-with-grace](https://www.npmjs.com/package/close-with-grace?activeTab=readme#usage) package from fastify authors. Shuts down the server on the following events

- process.once('SIGTERM')
- process.once('SIGINT')
- process.once('uncaughtException')
- process.once('unhandledRejection')

## Additional context

Tested with `docker-compose.yml`
```bash
$ docker compose up --build
...
[+] Running 1/1
 ✔ Container postgres-meta-meta-1  Recreated                                           0.1s 
Attaching to postgres-meta-meta-1
postgres-meta-meta-1  | (node:1) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
postgres-meta-meta-1  | (Use `node --trace-warnings ...` to show where the warning was created)
postgres-meta-meta-1  | {"level":"info","time":"2024-02-21T10:03:46.750Z","pid":1,"hostname":"dce592e0de3a","msg":"Server listening at http://0.0.0.0:8080"}
postgres-meta-meta-1  | {"level":"info","time":"2024-02-21T10:03:46.757Z","pid":1,"hostname":"dce592e0de3a","msg":"Server listening at http://0.0.0.0:8081"}
^CGracefully stopping... (press Ctrl+C again to force)
Aborting on container exit...
[+] Running 1/1
 ✔ Container postgres-meta-meta-1  Stopped                                             0.2s 
canceled
```