### PR TITLE
fix(ci): flaky release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - id: semantic-release
         uses: cycjimmy/semantic-release-action@v4
         with:
-          semantic_version: 18
+          semantic_version: 21
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We keep getting this error from semantic-release:

HttpError: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.

This is supposedly fixed in https://github.com/semantic-release/github/pull/487.