### PR TITLE
fix: query timeout

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -43,7 +43,7 @@ export const GENERATE_TYPES_DETECT_ONE_TO_ONE_RELATIONSHIPS =
 
 export const DEFAULT_POOL_CONFIG: PoolConfig = {
   max: 1,
-  connectionTimeoutMillis: PG_CONN_TIMEOUT_SECS * 1000,
+  query_timeout: PG_CONN_TIMEOUT_SECS * 1000,
   ssl: PG_META_DB_SSL_ROOT_CERT ? { ca: PG_META_DB_SSL_ROOT_CERT } : undefined,
 }
 

--- a/test/server/query.ts
+++ b/test/server/query.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { app } from './utils'
+import { DEFAULT_POOL_CONFIG } from '../../src/server/constants'
 
 test('query', async () => {
   const res = await app.inject({
@@ -538,4 +539,18 @@ test('very big number', async () => {
       },
     ]
   `)
+})
+
+test('query timeout', async () => {
+  const defaultTimeout = DEFAULT_POOL_CONFIG.query_timeout
+  DEFAULT_POOL_CONFIG.query_timeout = 100
+
+  const res = await app.inject({
+    method: 'POST',
+    path: '/query',
+    payload: { query: "select pg_sleep_for('1 minute');" },
+  })
+  expect(res.json()?.error).toMatchInlineSnapshot(`"Query read timeout"`)
+
+  DEFAULT_POOL_CONFIG.query_timeout = defaultTimeout
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Testing locally, `select pg_sleep(<forever>)` just hangs even past the `connectionTimeoutMillis`

## What is the new behavior?

Use `query_timeout` instead which returns `Query read timeout` with a 400