### PR TITLE
fix: support gen types from command line

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -17,7 +17,6 @@ import {
 import { apply as applyTypescriptTemplate } from './templates/typescript.js'
 import { apply as applyGoTemplate } from './templates/go.js'
 import { apply as applySwiftTemplate } from './templates/swift.js'
-import { getGeneratorMetadata } from '../lib/generators.js'
 
 const logger = pino({
   formatters: {
@@ -32,48 +31,6 @@ const app = buildApp({ logger })
 const adminApp = buildAdminApp({ logger })
 
 async function getTypeOutput(): Promise<string | null> {
-  const pgMeta: PostgresMeta = new PostgresMeta({
-    ...DEFAULT_POOL_CONFIG,
-    connectionString: PG_CONNECTION,
-  })
-  const { data: generatorMetadata, error: generatorMetadataError } = await getGeneratorMetadata(
-    pgMeta,
-    {
-      includedSchemas: GENERATE_TYPES_INCLUDED_SCHEMAS,
-    }
-  )
-  if (generatorMetadataError) {
-    throw new Error(generatorMetadataError.message)
-  }
-
-  let output: string | null = null
-  switch (GENERATE_TYPES) {
-    case 'typescript':
-      output = await applyTypescriptTemplate({
-        ...generatorMetadata,
-        detectOneToOneRelationships: GENERATE_TYPES_DETECT_ONE_TO_ONE_RELATIONSHIPS,
-      })
-      break
-    case 'swift':
-      output = await applySwiftTemplate({
-        ...generatorMetadata,
-        accessControl: GENERATE_TYPES_SWIFT_ACCESS_CONTROL,
-      })
-    case 'go':
-      output = applyGoTemplate(generatorMetadata)
-      break
-  }
-
-  return output
-}
-
-if (EXPORT_DOCS) {
-  // TODO: Move to a separate script.
-  await app.ready()
-  // @ts-ignore: app.swagger() is a Fastify decorator, so doesn't show up in the types
-  console.log(JSON.stringify(app.swagger(), null, 2))
-} else if (GENERATE_TYPES === 'typescript') {
-  // TODO: Move to a separate script.
   const pgMeta: PostgresMeta = new PostgresMeta({
     ...DEFAULT_POOL_CONFIG,
     connectionString: PG_CONNECTION,
@@ -154,26 +111,47 @@ if (EXPORT_DOCS) {
     throw new Error(typesError.message)
   }
 
-  console.log(
-    await applyTypescriptTemplate({
-      schemas: schemas!.filter(
-        ({ name }) =>
-          GENERATE_TYPES_INCLUDED_SCHEMAS.length === 0 ||
-          GENERATE_TYPES_INCLUDED_SCHEMAS.includes(name)
-      ),
-      tables: tables!,
-      foreignTables: foreignTables!,
-      views: views!,
-      materializedViews: materializedViews!,
-      columns: columns!,
-      relationships: relationships!,
-      functions: functions!.filter(
-        ({ return_type }) => !['trigger', 'event_trigger'].includes(return_type)
-      ),
-      types: types!,
-      detectOneToOneRelationships: GENERATE_TYPES_DETECT_ONE_TO_ONE_RELATIONSHIPS,
-    })
-  )
+  const config = {
+    schemas: schemas!.filter(
+      ({ name }) =>
+        GENERATE_TYPES_INCLUDED_SCHEMAS.length === 0 ||
+        GENERATE_TYPES_INCLUDED_SCHEMAS.includes(name)
+    ),
+    tables: tables!,
+    foreignTables: foreignTables!,
+    views: views!,
+    materializedViews: materializedViews!,
+    columns: columns!,
+    relationships: relationships!,
+    functions: functions!.filter(
+      ({ return_type }) => !['trigger', 'event_trigger'].includes(return_type)
+    ),
+    types: types!,
+    detectOneToOneRelationships: GENERATE_TYPES_DETECT_ONE_TO_ONE_RELATIONSHIPS,
+  }
+
+  switch (GENERATE_TYPES?.toLowerCase()) {
+    case 'typescript':
+      return await applyTypescriptTemplate(config)
+    case 'swift':
+      return await applySwiftTemplate({
+        ...config,
+        accessControl: GENERATE_TYPES_SWIFT_ACCESS_CONTROL,
+      })
+    case 'go':
+      return applyGoTemplate(config)
+    default:
+      throw new Error(`Unsupported language for GENERATE_TYPES: ${GENERATE_TYPES}`)
+  }
+}
+
+if (EXPORT_DOCS) {
+  // TODO: Move to a separate script.
+  await app.ready()
+  // @ts-ignore: app.swagger() is a Fastify decorator, so doesn't show up in the types
+  console.log(JSON.stringify(app.swagger(), null, 2))
+} else if (GENERATE_TYPES) {
+  console.log(await getTypeOutput())
 } else {
   const closeListeners = closeWithGrace(async ({ err }) => {
     if (err) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Support typegen from cli mode so that scripts in [package.json](https://github.com/supabase/postgres-meta/blob/master/package.json#L26) continue to work.

## Additional context

Add any other context or screenshots.
