### PR TITLE
fix: return `interval` as string

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -12,6 +12,7 @@ pg.types.setTypeParser(pg.types.builtins.INT8, (x) => {
   }
 })
 pg.types.setTypeParser(pg.types.builtins.DATE, (x) => x)
+pg.types.setTypeParser(pg.types.builtins.INTERVAL, (x) => x)
 pg.types.setTypeParser(pg.types.builtins.TIMESTAMP, (x) => x)
 pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, (x) => x)
 pg.types.setTypeParser(1115, parseArray) // _timestamp

--- a/test/server/query.ts
+++ b/test/server/query.ts
@@ -539,3 +539,21 @@ test('very big number', async () => {
     ]
   `)
 })
+
+// issue: https://github.com/supabase/supabase/issues/27626
+test('return interval as string', async () => {
+  const res = await app.inject({
+    method: 'POST',
+    path: '/query',
+    payload: {
+      query: `SELECT '1 day 1 hour 45 minutes'::interval`,
+    },
+  })
+  expect(res.json()).toMatchInlineSnapshot(`
+    [
+      {
+        "interval": "1 day 01:45:00",
+      },
+    ]
+  `)
+})


### PR DESCRIPTION
[Context](https://github.com/supabase/supabase/issues/27626)