### PR TITLE
omit columns from /tables

### DIFF
--- a/src/server/routes/tables.ts
+++ b/src/server/routes/tables.ts
@@ -24,7 +24,7 @@ const route: FastifyPluginAsyncTypebox = async (fastify) => {
           excluded_schemas: Type.Optional(Type.String()),
           limit: Type.Optional(Type.Integer()),
           offset: Type.Optional(Type.Integer()),
-          include_columns: Type.Optional(Type.Boolean()),
+          include_columns: Type.Optional(Type.Boolean({ default: false })),
         }),
         response: {
           200: Type.Array(postgresTableSchema),


### PR DESCRIPTION
## What kind of change does this PR introduce?

implement feature from https://github.com/supabase/postgres-meta/issues/250

## What is the current behavior?

by default `/tables` will return all columns

## What is the new behavior?

`/tables` will not return columns, except add query param `include_columns=true`

