### PR TITLE
fix: Close both apps to allow for process restart

### DIFF
--- a/src/server/admin-app.ts
+++ b/src/server/admin-app.ts
@@ -1,11 +1,9 @@
 import { fastify, FastifyInstance, FastifyServerOptions } from 'fastify'
-
-import FastifyMetrics from 'fastify-metrics'
+import fastifyMetrics from 'fastify-metrics'
 
 export function build(opts: FastifyServerOptions = {}): FastifyInstance {
   const app = fastify(opts)
-  // @ts-ignore fastify-metrics doesn't work with NodeNext resolution
-  app.register(FastifyMetrics, {
+  app.register(fastifyMetrics.default, {
     endpoint: '/metrics',
     routeMetrics: { enabled: false },
   })

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -158,9 +158,15 @@ if (EXPORT_DOCS) {
       app.log.error(err)
     }
     await app.close()
+    await adminApp.close()
   })
   app.addHook('onClose', async () => {
     closeListeners.uninstall()
+    await adminApp.close()
+  })
+  adminApp.addHook('onClose', async () => {
+    closeListeners.uninstall()
+    await app.close()
   })
 
   app.listen({ port: PG_META_PORT, host: PG_META_HOST }, (err) => {


### PR DESCRIPTION
Currently when the main `app` is closed, or any node.js termination signal is sent (which is hijacked by `closeWithGrace` https://github.com/mcollina/close-with-grace?tab=readme-ov-file#api), an `adminApp` instance will keep it hostage and won't allow ec2 to restart everything correctly.

This can be tested by updating `/health` endpoint to call `app.close()` and observing that process is still running due to `adminApp` server being bound.

This will hopefully kill server instantly and won't let other requests come in to this instance as observed in our ec2 logs now.

Sidenote: why do we expose prometheus metrics on a separate port/app and not just `/metrics` endpoint within same app instead? @soedirgo 