### PR TITLE
Add constant arrays of enum values for typescript

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -391,6 +391,26 @@ export type Database = {
     })}
 }
 
+export const Constants = {
+  ${schemas
+    .sort(({ name: a }, { name: b }) => a.localeCompare(b))
+    .map((schema) => {
+      const schemaEnums = types
+        .filter((type) => type.schema === schema.name && type.enums.length > 0)
+        .sort(({ name: a }, { name: b }) => a.localeCompare(b))
+      return `${JSON.stringify(schema.name)}: {
+          Enums: {
+            ${schemaEnums.map(
+              (enum_) =>
+                `${JSON.stringify(enum_.name)}: [${enum_.enums
+                  .map((variant) => JSON.stringify(variant))
+                  .join(', ')}]`
+            )}
+          }
+        }`
+    })}
+} as const
+
 type DefaultSchema = Database[Extract<keyof Database, ${JSON.stringify(GENERATE_TYPES_DEFAULT_SCHEMA)}>]
 
 export type Tables<

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -391,26 +391,6 @@ export type Database = {
     })}
 }
 
-export const Constants = {
-  ${schemas
-    .sort(({ name: a }, { name: b }) => a.localeCompare(b))
-    .map((schema) => {
-      const schemaEnums = types
-        .filter((type) => type.schema === schema.name && type.enums.length > 0)
-        .sort(({ name: a }, { name: b }) => a.localeCompare(b))
-      return `${JSON.stringify(schema.name)}: {
-          Enums: {
-            ${schemaEnums.map(
-              (enum_) =>
-                `${JSON.stringify(enum_.name)}: [${enum_.enums
-                  .map((variant) => JSON.stringify(variant))
-                  .join(', ')}]`
-            )}
-          }
-        }`
-    })}
-} as const
-
 type DefaultSchema = Database[Extract<keyof Database, ${JSON.stringify(GENERATE_TYPES_DEFAULT_SCHEMA)}>]
 
 export type Tables<
@@ -515,6 +495,26 @@ export type CompositeTypes<
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+
+export const Constants = {
+  ${schemas
+    .sort(({ name: a }, { name: b }) => a.localeCompare(b))
+    .map((schema) => {
+      const schemaEnums = types
+        .filter((type) => type.schema === schema.name && type.enums.length > 0)
+        .sort(({ name: a }, { name: b }) => a.localeCompare(b))
+      return `${JSON.stringify(schema.name)}: {
+          Enums: {
+            ${schemaEnums.map(
+              (enum_) =>
+                `${JSON.stringify(enum_.name)}: [${enum_.enums
+                  .map((variant) => JSON.stringify(variant))
+                  .join(', ')}]`
+            )}
+          }
+        }`
+    })}
+} as const
 `
 
   output = await prettier.format(output, {

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -431,15 +431,6 @@ test('typegen: typescript', async () => {
       }
     }
 
-    export const Constants = {
-      public: {
-        Enums: {
-          meme_status: ["new", "old", "retired"],
-          user_status: ["ACTIVE", "INACTIVE"],
-        },
-      },
-    } as const
-
     type DefaultSchema = Database[Extract<keyof Database, "public">]
 
     export type Tables<
@@ -544,6 +535,15 @@ test('typegen: typescript', async () => {
       : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
         ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
         : never
+
+    export const Constants = {
+      public: {
+        Enums: {
+          meme_status: ["new", "old", "retired"],
+          user_status: ["ACTIVE", "INACTIVE"],
+        },
+      },
+    } as const
     "
   `)
 })
@@ -995,15 +995,6 @@ test('typegen w/ one-to-one relationships', async () => {
       }
     }
 
-    export const Constants = {
-      public: {
-        Enums: {
-          meme_status: ["new", "old", "retired"],
-          user_status: ["ACTIVE", "INACTIVE"],
-        },
-      },
-    } as const
-
     type DefaultSchema = Database[Extract<keyof Database, "public">]
 
     export type Tables<
@@ -1108,6 +1099,15 @@ test('typegen w/ one-to-one relationships', async () => {
       : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
         ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
         : never
+
+    export const Constants = {
+      public: {
+        Enums: {
+          meme_status: ["new", "old", "retired"],
+          user_status: ["ACTIVE", "INACTIVE"],
+        },
+      },
+    } as const
     "
   `)
 })
@@ -1559,15 +1559,6 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
       }
     }
 
-    export const Constants = {
-      public: {
-        Enums: {
-          meme_status: ["new", "old", "retired"],
-          user_status: ["ACTIVE", "INACTIVE"],
-        },
-      },
-    } as const
-
     type DefaultSchema = Database[Extract<keyof Database, "public">]
 
     export type Tables<
@@ -1672,6 +1663,15 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
       : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
         ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
         : never
+
+    export const Constants = {
+      public: {
+        Enums: {
+          meme_status: ["new", "old", "retired"],
+          user_status: ["ACTIVE", "INACTIVE"],
+        },
+      },
+    } as const
     "
   `)
 })

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -431,6 +431,15 @@ test('typegen: typescript', async () => {
       }
     }
 
+    export const Constants = {
+      public: {
+        Enums: {
+          meme_status: ["new", "old", "retired"],
+          user_status: ["ACTIVE", "INACTIVE"],
+        },
+      },
+    } as const
+
     type DefaultSchema = Database[Extract<keyof Database, "public">]
 
     export type Tables<
@@ -986,6 +995,15 @@ test('typegen w/ one-to-one relationships', async () => {
       }
     }
 
+    export const Constants = {
+      public: {
+        Enums: {
+          meme_status: ["new", "old", "retired"],
+          user_status: ["ACTIVE", "INACTIVE"],
+        },
+      },
+    } as const
+
     type DefaultSchema = Database[Extract<keyof Database, "public">]
 
     export type Tables<
@@ -1540,6 +1558,15 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
         }
       }
     }
+
+    export const Constants = {
+      public: {
+        Enums: {
+          meme_status: ["new", "old", "retired"],
+          user_status: ["ACTIVE", "INACTIVE"],
+        },
+      },
+    } as const
 
     type DefaultSchema = Database[Extract<keyof Database, "public">]
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Extends typescript schema generation to provide access to constants representing enum values.

Resolves #832

Resolves #864 

## What is the current behavior?

Generated schema provides type data for database enums.

## What is the new behavior?

Generated schema provides type data and constant values for database enums.

## Additional context
