### PR TITLE
fix(template): dynamically set default schema alias in typescript type generation

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -54,3 +54,5 @@ export const DEFAULT_POOL_CONFIG: PoolConfig = {
 }
 
 export const PG_META_REQ_HEADER = process.env.PG_META_REQ_HEADER || 'request-id'
+
+export const DEFAULT_SCHEMA = process.env.PG_META_GENERATE_TYPES_DEFAULT_SCHEMA

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -40,12 +40,15 @@ export const GENERATE_TYPES = process.env.PG_META_GENERATE_TYPES
 export const GENERATE_TYPES_INCLUDED_SCHEMAS = GENERATE_TYPES
   ? (process.env.PG_META_GENERATE_TYPES_INCLUDED_SCHEMAS?.split(',') ?? [])
   : []
+export const GENERATE_TYPES_DEFAULT_SCHEMA =
+  process.env.PG_META_GENERATE_TYPES_DEFAULT_SCHEMA || 'public'
 export const GENERATE_TYPES_DETECT_ONE_TO_ONE_RELATIONSHIPS =
   process.env.PG_META_GENERATE_TYPES_DETECT_ONE_TO_ONE_RELATIONSHIPS === 'true'
 export const GENERATE_TYPES_SWIFT_ACCESS_CONTROL = process.env
   .PG_META_GENERATE_TYPES_SWIFT_ACCESS_CONTROL
   ? (process.env.PG_META_GENERATE_TYPES_SWIFT_ACCESS_CONTROL as AccessControl)
   : 'internal'
+
 export const DEFAULT_POOL_CONFIG: PoolConfig = {
   max: 1,
   connectionTimeoutMillis: PG_CONN_TIMEOUT_SECS * 1000,
@@ -54,5 +57,3 @@ export const DEFAULT_POOL_CONFIG: PoolConfig = {
 }
 
 export const PG_META_REQ_HEADER = process.env.PG_META_REQ_HEADER || 'request-id'
-
-export const DEFAULT_SCHEMA = process.env.PG_META_GENERATE_TYPES_DEFAULT_SCHEMA

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -8,8 +8,7 @@ import type {
   PostgresView,
 } from '../../lib/index.js'
 import type { GeneratorMetadata } from '../../lib/generators.js'
-
-const defaultSchema = process.env.PG_META_GENERATE_TYPES_DEFAULT_SCHEMA
+import { DEFAULT_SCHEMA } from '../constants.js'
 
 export const apply = async ({
   schemas,
@@ -392,18 +391,12 @@ export type Database = {
     })}
 }
 
-${
-  defaultSchema
-    ? `export type DefaultSchema = Database[Extract<keyof Database, ${JSON.stringify(defaultSchema)}>]
-  export type DefaultSchemaOrPublic = DefaultSchema`
-    : `export type PublicSchema = Database[Extract<keyof Database, "public">]
-  export type DefaultSchemaOrPublic = PublicSchema`
-}
+ type DefaultSchema = Database[Extract<keyof Database, ${JSON.stringify(DEFAULT_SCHEMA) || '"public"'}>]
 
 
 export type Tables<
   PublicTableNameOrOptions extends
-    | keyof (DefaultSchemaOrPublic["Tables"] & DefaultSchemaOrPublic["Views"])
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
@@ -416,8 +409,8 @@ export type Tables<
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (DefaultSchemaOrPublic["Tables"] & DefaultSchemaOrPublic["Views"])
-    ? (DefaultSchemaOrPublic["Tables"] & DefaultSchemaOrPublic["Views"])[PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[PublicTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -426,7 +419,7 @@ export type Tables<
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
-    | keyof DefaultSchemaOrPublic["Tables"]
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
@@ -437,8 +430,8 @@ export type TablesInsert<
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof DefaultSchemaOrPublic["Tables"]
-  ? DefaultSchemaOrPublic["Tables"][PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof DefaultSchema["Tables"]
+  ? DefaultSchema["Tables"][PublicTableNameOrOptions] extends {
       Insert: infer I
     }
     ? I
@@ -447,7 +440,7 @@ export type TablesInsert<
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
-    | keyof DefaultSchemaOrPublic["Tables"]
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
@@ -458,8 +451,8 @@ export type TablesUpdate<
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof DefaultSchemaOrPublic["Tables"]
-  ? DefaultSchemaOrPublic["Tables"][PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof DefaultSchema["Tables"]
+  ? DefaultSchema["Tables"][PublicTableNameOrOptions] extends {
       Update: infer U
     }
     ? U
@@ -468,28 +461,28 @@ export type TablesUpdate<
 
 export type Enums<
   PublicEnumNameOrOptions extends
-    | keyof DefaultSchemaOrPublic["Enums"]
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
     : never = never
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof DefaultSchemaOrPublic["Enums"]
-  ? DefaultSchemaOrPublic["Enums"][PublicEnumNameOrOptions]
+  : PublicEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+  ? DefaultSchema["Enums"][PublicEnumNameOrOptions]
   : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchemaOrPublic['CompositeTypes']
+    | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
     : never = never
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
   ? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchemaOrPublic['CompositeTypes']
-    ? DefaultSchemaOrPublic['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
     : never;
 `
 

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -9,6 +9,8 @@ import type {
 } from '../../lib/index.js'
 import type { GeneratorMetadata } from '../../lib/generators.js'
 
+const defaultSchema = process.env.PG_META_GENERATE_TYPES_DEFAULT_SCHEMA
+
 export const apply = async ({
   schemas,
   tables,
@@ -390,11 +392,18 @@ export type Database = {
     })}
 }
 
-type PublicSchema = Database[Extract<keyof Database, "public">]
+${
+  defaultSchema
+    ? `export type DefaultSchema = Database[Extract<keyof Database, ${JSON.stringify(defaultSchema)}>]
+  export type DefaultSchemaOrPublic = DefaultSchema`
+    : `export type PublicSchema = Database[Extract<keyof Database, "public">]
+  export type DefaultSchemaOrPublic = PublicSchema`
+}
+
 
 export type Tables<
   PublicTableNameOrOptions extends
-    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | keyof (DefaultSchemaOrPublic["Tables"] & DefaultSchemaOrPublic["Views"])
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
@@ -407,8 +416,8 @@ export type Tables<
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-    ? (PublicSchema["Tables"] & PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof (DefaultSchemaOrPublic["Tables"] & DefaultSchemaOrPublic["Views"])
+    ? (DefaultSchemaOrPublic["Tables"] & DefaultSchemaOrPublic["Views"])[PublicTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -417,7 +426,7 @@ export type Tables<
 
 export type TablesInsert<
   PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
+    | keyof DefaultSchemaOrPublic["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
@@ -428,8 +437,8 @@ export type TablesInsert<
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof DefaultSchemaOrPublic["Tables"]
+  ? DefaultSchemaOrPublic["Tables"][PublicTableNameOrOptions] extends {
       Insert: infer I
     }
     ? I
@@ -438,7 +447,7 @@ export type TablesInsert<
 
 export type TablesUpdate<
   PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
+    | keyof DefaultSchemaOrPublic["Tables"]
     | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
@@ -449,8 +458,8 @@ export type TablesUpdate<
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : PublicTableNameOrOptions extends keyof DefaultSchemaOrPublic["Tables"]
+  ? DefaultSchemaOrPublic["Tables"][PublicTableNameOrOptions] extends {
       Update: infer U
     }
     ? U
@@ -459,28 +468,28 @@ export type TablesUpdate<
 
 export type Enums<
   PublicEnumNameOrOptions extends
-    | keyof PublicSchema["Enums"]
+    | keyof DefaultSchemaOrPublic["Enums"]
     | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
     : never = never
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-  ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+  : PublicEnumNameOrOptions extends keyof DefaultSchemaOrPublic["Enums"]
+  ? DefaultSchemaOrPublic["Enums"][PublicEnumNameOrOptions]
   : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof PublicSchema['CompositeTypes']
+    | keyof DefaultSchemaOrPublic['CompositeTypes']
     | { schema: keyof Database },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
     ? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
     : never = never
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
   ? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema['CompositeTypes']
-    ? PublicSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchemaOrPublic['CompositeTypes']
+    ? DefaultSchemaOrPublic['CompositeTypes'][PublicCompositeTypeNameOrOptions]
     : never;
 `
 

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -8,7 +8,7 @@ import type {
   PostgresView,
 } from '../../lib/index.js'
 import type { GeneratorMetadata } from '../../lib/generators.js'
-import { DEFAULT_SCHEMA } from '../constants.js'
+import { GENERATE_TYPES_DEFAULT_SCHEMA } from '../constants.js'
 
 export const apply = async ({
   schemas,
@@ -391,26 +391,29 @@ export type Database = {
     })}
 }
 
- type DefaultSchema = Database[Extract<keyof Database, ${JSON.stringify(DEFAULT_SCHEMA) || '"public"'}>]
-
+type DefaultSchema = Database[Extract<keyof Database, ${JSON.stringify(GENERATE_TYPES_DEFAULT_SCHEMA)}>]
 
 export type Tables<
-  PublicTableNameOrOptions extends
+  DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-        Database[PublicTableNameOrOptions["schema"]]["Views"])
-    : never = never
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -418,72 +421,80 @@ export type Tables<
     : never
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends
+  DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof DefaultSchema["Tables"]
-  ? DefaultSchema["Tables"][PublicTableNameOrOptions] extends {
-      Insert: infer I
-    }
-    ? I
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
     : never
-  : never
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends
+  DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof DefaultSchema["Tables"]
-  ? DefaultSchema["Tables"][PublicTableNameOrOptions] extends {
-      Update: infer U
-    }
-    ? U
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
     : never
-  : never
 
 export type Enums<
-  PublicEnumNameOrOptions extends
+  DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof Database },
-  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-    : never = never
-> = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-  ? DefaultSchema["Enums"][PublicEnumNameOrOptions]
-  : never
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
+    | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof Database },
-  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
-    : never = never
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
-    : never;
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
 `
 
   output = await prettier.format(output, {

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -431,27 +431,29 @@ test('typegen: typescript', async () => {
       }
     }
 
-    type PublicSchema = Database[Extract<keyof Database, "public">]
+    type DefaultSchema = Database[Extract<keyof Database, "public">]
 
     export type Tables<
-      PublicTableNameOrOptions extends
-        | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+      DefaultSchemaTableNameOrOptions extends
+        | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
         | { schema: keyof Database },
-      TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-        ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-            Database[PublicTableNameOrOptions["schema"]]["Views"])
+      TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+            Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
         : never = never,
-    > = PublicTableNameOrOptions extends { schema: keyof Database }
-      ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-          Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+    > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+      ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+          Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
           Row: infer R
         }
         ? R
         : never
-      : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-            PublicSchema["Views"])
-        ? (PublicSchema["Tables"] &
-            PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+      : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+            DefaultSchema["Views"])
+        ? (DefaultSchema["Tables"] &
+            DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
             Row: infer R
           }
           ? R
@@ -459,20 +461,22 @@ test('typegen: typescript', async () => {
         : never
 
     export type TablesInsert<
-      PublicTableNameOrOptions extends
-        | keyof PublicSchema["Tables"]
+      DefaultSchemaTableNameOrOptions extends
+        | keyof DefaultSchema["Tables"]
         | { schema: keyof Database },
-      TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-        ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+      TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
         : never = never,
-    > = PublicTableNameOrOptions extends { schema: keyof Database }
-      ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+    > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+      ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
           Insert: infer I
         }
         ? I
         : never
-      : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-        ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+        ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
             Insert: infer I
           }
           ? I
@@ -480,20 +484,22 @@ test('typegen: typescript', async () => {
         : never
 
     export type TablesUpdate<
-      PublicTableNameOrOptions extends
-        | keyof PublicSchema["Tables"]
+      DefaultSchemaTableNameOrOptions extends
+        | keyof DefaultSchema["Tables"]
         | { schema: keyof Database },
-      TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-        ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+      TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
         : never = never,
-    > = PublicTableNameOrOptions extends { schema: keyof Database }
-      ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+    > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+      ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
           Update: infer U
         }
         ? U
         : never
-      : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-        ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+        ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
             Update: infer U
           }
           ? U
@@ -501,21 +507,23 @@ test('typegen: typescript', async () => {
         : never
 
     export type Enums<
-      PublicEnumNameOrOptions extends
-        | keyof PublicSchema["Enums"]
+      DefaultSchemaEnumNameOrOptions extends
+        | keyof DefaultSchema["Enums"]
         | { schema: keyof Database },
-      EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-        ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+      EnumName extends DefaultSchemaEnumNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
         : never = never,
-    > = PublicEnumNameOrOptions extends { schema: keyof Database }
-      ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-      : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-        ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    > = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
+      ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+      : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+        ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
         : never
 
     export type CompositeTypes<
       PublicCompositeTypeNameOrOptions extends
-        | keyof PublicSchema["CompositeTypes"]
+        | keyof DefaultSchema["CompositeTypes"]
         | { schema: keyof Database },
       CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
         schema: keyof Database
@@ -524,8 +532,8 @@ test('typegen: typescript', async () => {
         : never = never,
     > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
       ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-      : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-        ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+      : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+        ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
         : never
     "
   `)
@@ -978,27 +986,29 @@ test('typegen w/ one-to-one relationships', async () => {
       }
     }
 
-    type PublicSchema = Database[Extract<keyof Database, "public">]
+    type DefaultSchema = Database[Extract<keyof Database, "public">]
 
     export type Tables<
-      PublicTableNameOrOptions extends
-        | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+      DefaultSchemaTableNameOrOptions extends
+        | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
         | { schema: keyof Database },
-      TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-        ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-            Database[PublicTableNameOrOptions["schema"]]["Views"])
+      TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+            Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
         : never = never,
-    > = PublicTableNameOrOptions extends { schema: keyof Database }
-      ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-          Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+    > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+      ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+          Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
           Row: infer R
         }
         ? R
         : never
-      : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-            PublicSchema["Views"])
-        ? (PublicSchema["Tables"] &
-            PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+      : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+            DefaultSchema["Views"])
+        ? (DefaultSchema["Tables"] &
+            DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
             Row: infer R
           }
           ? R
@@ -1006,20 +1016,22 @@ test('typegen w/ one-to-one relationships', async () => {
         : never
 
     export type TablesInsert<
-      PublicTableNameOrOptions extends
-        | keyof PublicSchema["Tables"]
+      DefaultSchemaTableNameOrOptions extends
+        | keyof DefaultSchema["Tables"]
         | { schema: keyof Database },
-      TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-        ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+      TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
         : never = never,
-    > = PublicTableNameOrOptions extends { schema: keyof Database }
-      ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+    > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+      ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
           Insert: infer I
         }
         ? I
         : never
-      : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-        ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+        ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
             Insert: infer I
           }
           ? I
@@ -1027,20 +1039,22 @@ test('typegen w/ one-to-one relationships', async () => {
         : never
 
     export type TablesUpdate<
-      PublicTableNameOrOptions extends
-        | keyof PublicSchema["Tables"]
+      DefaultSchemaTableNameOrOptions extends
+        | keyof DefaultSchema["Tables"]
         | { schema: keyof Database },
-      TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-        ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+      TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
         : never = never,
-    > = PublicTableNameOrOptions extends { schema: keyof Database }
-      ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+    > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+      ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
           Update: infer U
         }
         ? U
         : never
-      : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-        ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+        ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
             Update: infer U
           }
           ? U
@@ -1048,21 +1062,23 @@ test('typegen w/ one-to-one relationships', async () => {
         : never
 
     export type Enums<
-      PublicEnumNameOrOptions extends
-        | keyof PublicSchema["Enums"]
+      DefaultSchemaEnumNameOrOptions extends
+        | keyof DefaultSchema["Enums"]
         | { schema: keyof Database },
-      EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-        ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+      EnumName extends DefaultSchemaEnumNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
         : never = never,
-    > = PublicEnumNameOrOptions extends { schema: keyof Database }
-      ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-      : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-        ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    > = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
+      ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+      : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+        ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
         : never
 
     export type CompositeTypes<
       PublicCompositeTypeNameOrOptions extends
-        | keyof PublicSchema["CompositeTypes"]
+        | keyof DefaultSchema["CompositeTypes"]
         | { schema: keyof Database },
       CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
         schema: keyof Database
@@ -1071,8 +1087,8 @@ test('typegen w/ one-to-one relationships', async () => {
         : never = never,
     > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
       ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-      : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-        ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+      : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+        ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
         : never
     "
   `)
@@ -1525,27 +1541,29 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
       }
     }
 
-    type PublicSchema = Database[Extract<keyof Database, "public">]
+    type DefaultSchema = Database[Extract<keyof Database, "public">]
 
     export type Tables<
-      PublicTableNameOrOptions extends
-        | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+      DefaultSchemaTableNameOrOptions extends
+        | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
         | { schema: keyof Database },
-      TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-        ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-            Database[PublicTableNameOrOptions["schema"]]["Views"])
+      TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+            Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
         : never = never,
-    > = PublicTableNameOrOptions extends { schema: keyof Database }
-      ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-          Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+    > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+      ? (Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+          Database[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
           Row: infer R
         }
         ? R
         : never
-      : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-            PublicSchema["Views"])
-        ? (PublicSchema["Tables"] &
-            PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+      : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+            DefaultSchema["Views"])
+        ? (DefaultSchema["Tables"] &
+            DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
             Row: infer R
           }
           ? R
@@ -1553,20 +1571,22 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
         : never
 
     export type TablesInsert<
-      PublicTableNameOrOptions extends
-        | keyof PublicSchema["Tables"]
+      DefaultSchemaTableNameOrOptions extends
+        | keyof DefaultSchema["Tables"]
         | { schema: keyof Database },
-      TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-        ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+      TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
         : never = never,
-    > = PublicTableNameOrOptions extends { schema: keyof Database }
-      ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+    > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+      ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
           Insert: infer I
         }
         ? I
         : never
-      : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-        ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+        ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
             Insert: infer I
           }
           ? I
@@ -1574,20 +1594,22 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
         : never
 
     export type TablesUpdate<
-      PublicTableNameOrOptions extends
-        | keyof PublicSchema["Tables"]
+      DefaultSchemaTableNameOrOptions extends
+        | keyof DefaultSchema["Tables"]
         | { schema: keyof Database },
-      TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-        ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+      TableName extends DefaultSchemaTableNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
         : never = never,
-    > = PublicTableNameOrOptions extends { schema: keyof Database }
-      ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+    > = DefaultSchemaTableNameOrOptions extends { schema: keyof Database }
+      ? Database[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
           Update: infer U
         }
         ? U
         : never
-      : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-        ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+        ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
             Update: infer U
           }
           ? U
@@ -1595,21 +1617,23 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
         : never
 
     export type Enums<
-      PublicEnumNameOrOptions extends
-        | keyof PublicSchema["Enums"]
+      DefaultSchemaEnumNameOrOptions extends
+        | keyof DefaultSchema["Enums"]
         | { schema: keyof Database },
-      EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-        ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+      EnumName extends DefaultSchemaEnumNameOrOptions extends {
+        schema: keyof Database
+      }
+        ? keyof Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
         : never = never,
-    > = PublicEnumNameOrOptions extends { schema: keyof Database }
-      ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-      : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-        ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    > = DefaultSchemaEnumNameOrOptions extends { schema: keyof Database }
+      ? Database[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+      : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+        ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
         : never
 
     export type CompositeTypes<
       PublicCompositeTypeNameOrOptions extends
-        | keyof PublicSchema["CompositeTypes"]
+        | keyof DefaultSchema["CompositeTypes"]
         | { schema: keyof Database },
       CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
         schema: keyof Database
@@ -1618,8 +1642,8 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
         : never = never,
     > = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
       ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-      : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-        ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+      : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+        ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
         : never
     "
   `)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes the incorrect default alias generation for TypeScript type schemas when using a single non‑public schema with `supabase gen types`.

## What is the current behavior?

Currently, the TypeScript template always hardcodes the default schema alias as:

```ts
export type PublicSchema = Database[Extract<keyof Database, "public">]
```

This means that when a user generates types using a non‑public schema (for example, `--schema robo`), the generated helper types (for example. `Tables<"test_table">`) incorrectly reference the public schema, even if no tables exist there.

Relevant issues: 
- cli:  [#3146](https://github.com/supabase/cli/issues/3146), [#3061](https://github.com/supabase/cli/issues/3061)
- postgres-meta: #833 (for additional context)

## What is the new behavior?

This PR updates the TypeScript template in pg‑meta so that when exactly one non‑public schema is provided, the template automatically uses the environment variable `PG_META_GENERATE_TYPES_DEFAULT_SCHEMA` to generate a default alias. For example, if the schema provided is "robo", the template will now output:

```ts
export type DefaultSchema = Database[Extract<keyof Database, "robo">]
export type DefaultSchemaOrPublic = DefaultSchema
```

The helper types (`Tables`, `TablesInsert`, etc.) reference `DefaultSchemaOrPublic` instead of the hardcoded "public". In multi‑schema scenarios, the environment variable is not set, and the default behavior (using "public") remains, the users can explicitly specify the schema for non-public tables.

This change ensures:

- In single‑schema mode with a non‑public schema, shorthand type references (like `Tables<"test_table">`) correctly resolve to `Database["robo"]["Tables"]["test_table"]`.
- In multi‑schema mode, users must explicitly specify which schema to use (for example, `Tables<{ schema: "robo" }, "test_table">`).

## Additional context
Usage example

```
CREATE SCHEMA robo;
CREATE TABLE robo.test_table (
  id SERIAL PRIMARY KEY,
  name TEXT
);


CREATE TABLE public.example_table (
  id SERIAL PRIMARY KEY,
  description TEXT
);
```

```ts
// Scenario 1: No schema flag (defaults to "public")
import * as PublicTypes from "./dbTypes-public";

type PublicExampleRow = PublicTypes.Tables<"example_table">;

// Scenario 2: Single non‑public schema (e.g. "robo")
import * as RoboTypes from "./dbTypesRobo";

type RoboExampleRow = RoboTypes.Tables<"test_table">;

// Scenario 3: Multiple schemas specified (e.g. "public" and "robo")
import * as MultiTypes from "./dbTypes-multi";

type MultiPublicRow = MultiTypes.Tables<"example_table">;
type MultiRoboRow = MultiTypes.Tables<{ schema: "robo" }, "test_table">;

// examples
const publicRow: PublicExampleRow = {
  id: 1,
  description: "A public record",
};


const roboRow: RoboExampleRow = {
  id: 10,
  name: "Robo record",
};

const multiPublicRow: MultiPublicRow = {
  id: 2,
  description: "Multi public record",
};

const multiRoboRow: MultiRoboRow = {
  id: 20,
  name: null,
};
```

Corresponding [cli PR](https://github.com/supabase/cli/pull/3243)