### PR TITLE
fix: rename max_result variable default to MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "test": "run-s db:clean db:run test:run db:clean",
     "db:clean": "cd test/db && docker compose down",
     "db:run": "cd test/db && docker compose up --detach --wait",
-    "test:run": "PG_META_MAX_RESULT_SIZE=20971520 vitest run --coverage",
-    "test:update": "run-s db:clean db:run && PG_META_MAX_RESULT_SIZE=20971520 vitest run --update && run-s db:clean"
+    "test:run": "PG_META_MAX_RESULT_SIZE_MB=20 vitest run --coverage",
+    "test:update": "run-s db:clean db:run && PG_META_MAX_RESULT_SIZE_MB=20 vitest run --update && run-s db:clean"
   },
   "engines": {
     "node": ">=20",

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -49,8 +49,10 @@ export const GENERATE_TYPES_SWIFT_ACCESS_CONTROL = process.env
   ? (process.env.PG_META_GENERATE_TYPES_SWIFT_ACCESS_CONTROL as AccessControl)
   : 'internal'
 
-export const PG_META_MAX_RESULT_SIZE = process.env.PG_META_MAX_RESULT_SIZE
-  ? parseInt(process.env.PG_META_MAX_RESULT_SIZE, 10)
+export const PG_META_MAX_RESULT_SIZE = process.env.PG_META_MAX_RESULT_SIZE_MB
+  ? // Node-postgres get a maximum size in bytes make the conversion from the env variable
+    // from MB to Bytes
+    parseInt(process.env.PG_META_MAX_RESULT_SIZE_MB, 10) * 1024 * 1024
   : 2 * 1024 * 1024 * 1024 // default to 2GB max query size result
 
 export const DEFAULT_POOL_CONFIG: PoolConfig = {


### PR DESCRIPTION
- Make the variable autodescriptive and the unit more easy to reason with Following comment from: https://github.com/supabase/infrastructure/pull/22299\#discussion_r2021926148

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
