### PR TITLE
chore: ignore sentryclirc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ typings/
 .env
 .env.test
 
+# sentry cli config
+.sentryclirc
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 


### PR DESCRIPTION
Since sentry is configured, make sure we never accidentally commit the sentry-cli config by accident