### PR TITLE
FIX: Add 'case' to list of Swift keywords for Swift type generation

### DIFF
--- a/src/server/templates/swift.ts
+++ b/src/server/templates/swift.ts
@@ -392,7 +392,7 @@ function formatForSwiftTypeName(name: string): string {
   )
 }
 
-const SWIFT_KEYWORDS = ['in', 'default']
+const SWIFT_KEYWORDS = ['in', 'default', 'case']
 
 /**
  * Converts a Postgres name to pascalCase.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds "case" to the list of Swift keywords so that a Postgres table with a column named 'case' won't cause the Swift type generation to produce invalid code.

## What is the current behavior?

`gen types swift` with a table that has a column named 'case' will produce the following code:
```swift
public let case: String        // ERROR: Keyword 'case' cannot be used as an identifier here. 
                               // FIX: If this name is unavoidable, use backticks to escape it
```

## What is the new behavior?

`case` will be encoded in backticks so there will be no error:
```swift
public let `case`: String
```

## Additional context

--
