### PR TITLE
fix(server): bump bodyLimit to 3MB default allow parameterize

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -3,14 +3,19 @@ import * as Sentry from '@sentry/node'
 import cors from '@fastify/cors'
 import swagger from '@fastify/swagger'
 import { fastify, FastifyInstance, FastifyServerOptions } from 'fastify'
-import { PG_META_REQ_HEADER } from './constants.js'
+import { PG_META_REQ_HEADER, MAX_BODY_LIMIT } from './constants.js'
 import routes from './routes/index.js'
 import { extractRequestForLogging } from './utils.js'
 // Pseudo package declared only for this module
 import pkg from '#package.json' with { type: 'json' }
 
 export const build = (opts: FastifyServerOptions = {}): FastifyInstance => {
-  const app = fastify({ disableRequestLogging: true, requestIdHeader: PG_META_REQ_HEADER, ...opts })
+  const app = fastify({
+    disableRequestLogging: true,
+    requestIdHeader: PG_META_REQ_HEADER,
+    bodyLimit: MAX_BODY_LIMIT,
+    ...opts,
+  })
   Sentry.setupFastifyErrorHandler(app)
 
   app.setErrorHandler((error, request, reply) => {

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -57,6 +57,11 @@ export const PG_META_MAX_RESULT_SIZE = process.env.PG_META_MAX_RESULT_SIZE_MB
     parseInt(process.env.PG_META_MAX_RESULT_SIZE_MB, 10) * 1024 * 1024
   : 2 * 1024 * 1024 * 1024 // default to 2GB max query size result
 
+export const MAX_BODY_LIMIT = process.env.PG_META_MAX_BODY_LIMIT_MB
+  ? // Fastify server max body size allowed, is in bytes, convert from MB to Bytes
+    parseInt(process.env.PG_META_MAX_BODY_LIMIT_MB, 10) * 1024 * 1024
+  : 3 * 1024 * 1024
+
 export const DEFAULT_POOL_CONFIG: PoolConfig = {
   max: 1,
   connectionTimeoutMillis: PG_CONN_TIMEOUT_SECS * 1000,


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Introduce `PG_META_MAX_BODY_LIMIT_MB` env variable to make easier parameterization
- Bump the default `bodyLimit` value from 1MB to 3MB.