### PR TITLE
fix(ts-template): correct "instanciate" to "instantiate" misspelling

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -35,7 +35,7 @@ export const apply = async ({
     .forEach((c) => columnsByTableId[c.table_id].push(c))
 
   const internal_supabase_schema = postgrestVersion
-    ? `// Allows to automatically instanciate createClient with right options
+    ? `// Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
     PostgrestVersion: '${postgrestVersion}'

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -1299,7 +1299,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
       | Json[]
 
     export type Database = {
-      // Allows to automatically instanciate createClient with right options
+      // Allows to automatically instantiate createClient with right options
       // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
       __InternalSupabase: {
         PostgrestVersion: "13"


### PR DESCRIPTION
# Fix spelling mistake in TypeScript generation template

Fix spelling mistake in TypeScript generation template that was propagating to all generated database type files.

## What kind of change does this PR introduce?

Bug fix - corrects spelling error in code generation template

## What is the current behavior?

The TypeScript generation template contains a spelling error where "instanciate" is used instead of the correct spelling "instantiate" in the comment:

```typescript
// Allows to automatically instanciate createClient with right options
```

This spelling error propagates to all generated `DatabaseDefinitions.ts` files for every user who runs `supabase gen types typescript`, affecting code quality and professionalism.

Please link any relevant issues here: Related to spell-checking failures in pre-commit hooks across user projects.

## What is the new behavior?

The comment now uses the correct spelling "instantiate":

```typescript
// Allows to automatically instantiate createClient with right options
```

All generated TypeScript database definition files will now contain proper spelling.

## Additional context

- This is a cosmetic fix with no functional changes
- Similar spelling errors exist in other Supabase repositories (supabase-flutter, gotrue-dart, postgrest-js)
- Improves developer experience by eliminating potential spell-check warnings in generated code