### PR TITLE
Allow strings for `numeric` type inserts and updates

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -144,6 +144,16 @@ export type Database = {
                         views,
                       })
 
+                      if (column.name.toLowerCase().startsWith("decimal")) {
+                        console.log("YOYOYOYO Insert", `'${column.name}'`, `'${column.format}'`)
+                      }
+
+                      // Numeric types can be inserted as strings to preserve
+                      // precision.
+                      if (column.format === "numeric") {
+                        output += '| string'
+                      }
+
                       if (column.is_nullable) {
                         output += '| null'
                       }
@@ -165,6 +175,12 @@ export type Database = {
                         tables,
                         views,
                       })}`
+
+                      // Numeric types can be inserted as strings to preserve
+                      // precision.
+                      if (column.format === "numeric") {
+                        output += '| string'
+                      }
 
                       if (column.is_nullable) {
                         output += '| null'

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -227,13 +227,13 @@ test('typegen: typescript', async () => {
               status: Database["public"]["Enums"]["user_status"] | null
             }
             Insert: {
-              decimal?: number | null
+              decimal?: number | string | null
               id?: number
               name?: string | null
               status?: Database["public"]["Enums"]["user_status"] | null
             }
             Update: {
-              decimal?: number | null
+              decimal?: number | string | null
               id?: number
               name?: string | null
               status?: Database["public"]["Enums"]["user_status"] | null
@@ -870,13 +870,13 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
               status: Database["public"]["Enums"]["user_status"] | null
             }
             Insert: {
-              decimal?: number | null
+              decimal?: number | string | null
               id?: number
               name?: string | null
               status?: Database["public"]["Enums"]["user_status"] | null
             }
             Update: {
-              decimal?: number | null
+              decimal?: number | string | null
               id?: number
               name?: string | null
               status?: Database["public"]["Enums"]["user_status"] | null
@@ -1528,13 +1528,13 @@ test('typegen: typescript w/ postgrestVersion', async () => {
               status: Database["public"]["Enums"]["user_status"] | null
             }
             Insert: {
-              decimal?: number | null
+              decimal?: number | string | null
               id?: number
               name?: string | null
               status?: Database["public"]["Enums"]["user_status"] | null
             }
             Update: {
-              decimal?: number | null
+              decimal?: number | string | null
               id?: number
               name?: string | null
               status?: Database["public"]["Enums"]["user_status"] | null
@@ -1682,7 +1682,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
               status: Database["public"]["Enums"]["user_status"] | null
             }
             Insert: {
-              decimal?: number | null
+              decimal?: number | string | null
               id?: number | null
               name?: string | null
               status?: Database["public"]["Enums"]["user_status"] | null


### PR DESCRIPTION
When generating TypeScript types, the current code "correctly" reports numeric types as `number`, as Postgres and Postgrest return such columns as JSON numbers by default without a query `::text` cast.

However, generated insert and update types are limited to `number`, whereas the underlying APIs will accept a string and allow preserving precision that would be lost in conversion to JS `number` this way.

Generated types for inserting and updating numeric fields now include `| string` as a possibility to allow for this.

Closes #972.