### PR TITLE
chore: refactor typegen to reduce loops

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -51,6 +51,10 @@ export const GENERATE_TYPES_SWIFT_ACCESS_CONTROL = process.env
   ? (process.env.PG_META_GENERATE_TYPES_SWIFT_ACCESS_CONTROL as AccessControl)
   : 'internal'
 
+// json/jsonb/text types
+export const VALID_UNNAMED_FUNCTION_ARG_TYPES = new Set([114, 3802, 25])
+export const VALID_FUNCTION_ARGS_MODE = new Set(['in', 'inout', 'variadic'])
+
 export const PG_META_MAX_RESULT_SIZE = process.env.PG_META_MAX_RESULT_SIZE_MB
   ? // Node-postgres get a maximum size in bytes make the conversion from the env variable
     // from MB to Bytes


### PR DESCRIPTION
## What kind of change does this PR introduce?

As asked here: https://github.com/supabase/postgres-meta/pull/971#issuecomment-3311357614

Split up the "refactoring" part of the typegen where we reduce all the loops into it's own PR so it's easier to review.

Will be refactoring the part where we isolate the function definition generation into it's own function in another PR.