### PR TITLE
fix(typescript): union unknown null

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -482,6 +482,14 @@ export const apply = async ({
   }`
     : ''
 
+  function generateNullableUnionTsType(tsType: string, isNullable: boolean) {
+    // Only add the null union if the type is not unknown as unknown already includes null
+    if (tsType === 'unknown' || !isNullable) {
+      return tsType
+    }
+    return `${tsType} | null`
+  }
+
   function generateColumnTsDefinition(
     schema: PostgresSchema,
     column: {
@@ -497,7 +505,7 @@ export const apply = async ({
       views: PostgresView[]
     }
   ) {
-    return `${JSON.stringify(column.name)}${column.is_optional ? '?' : ''}: ${pgTypeToTsType(schema, column.format, context)} ${column.is_nullable ? '| null' : ''}`
+    return `${JSON.stringify(column.name)}${column.is_optional ? '?' : ''}: ${generateNullableUnionTsType(pgTypeToTsType(schema, column.format, context), column.is_nullable)}`
   }
 
   let output = `
@@ -537,7 +545,7 @@ export type Database = {
                       ...schemaFunctions
                         .filter(({ fn }) => fn.argument_types === table.name)
                         .map(({ fn }) => {
-                          return `${JSON.stringify(fn.name)}: ${getFunctionReturnType(schema, fn)} | null`
+                          return `${JSON.stringify(fn.name)}: ${generateNullableUnionTsType(getFunctionReturnType(schema, fn), true)}`
                         }),
                     ]}
                   }
@@ -610,7 +618,7 @@ export type Database = {
                         .filter(({ fn }) => fn.argument_types === view.name)
                         .map(
                           ({ fn }) =>
-                            `${JSON.stringify(fn.name)}: ${getFunctionReturnType(schema, fn)} | null`
+                            `${JSON.stringify(fn.name)}: ${generateNullableUnionTsType(getFunctionReturnType(schema, fn), true)}`
                         ),
                     ]}
                   }
@@ -709,12 +717,15 @@ export type Database = {
                           const type = typesById.get(type_id)
                           let tsType = 'unknown'
                           if (type) {
-                            tsType = `${pgTypeToTsType(schema, type.name, {
-                              types,
-                              schemas,
-                              tables,
-                              views,
-                            })} | null`
+                            tsType = `${generateNullableUnionTsType(
+                              pgTypeToTsType(schema, type.name, {
+                                types,
+                                schemas,
+                                tables,
+                                views,
+                              }),
+                              true
+                            )}`
                           }
                           return `${JSON.stringify(name)}: ${tsType}`
                         })}

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -484,7 +484,7 @@ export const apply = async ({
 
   function generateNullableUnionTsType(tsType: string, isNullable: boolean) {
     // Only add the null union if the type is not unknown as unknown already includes null
-    if (tsType === 'unknown' || !isNullable) {
+    if (tsType === 'unknown' || tsType === 'any' || !isNullable) {
       return tsType
     }
     return `${tsType} | null`


### PR DESCRIPTION
`unknown`  and `any` already swallow nullable type, don't need an union for it, in such case we follow tslint best practice:
https://typescript-eslint.io/rules/no-redundant-type-constituents/

Fixes:
- https://github.com/supabase/cli/issues/4234
- https://github.com/supabase/cli/issues/577