### PR TITLE
chore:server logs for wsl 

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -18,7 +18,7 @@ import {
 import { apply as applyTypescriptTemplate } from './templates/typescript.js'
 import { apply as applyGoTemplate } from './templates/go.js'
 import { apply as applySwiftTemplate } from './templates/swift.js'
-
+import { isRunningInWSL } from './utils.js'
 const logger = pino({
   formatters: {
     level(label) {
@@ -197,10 +197,15 @@ if (EXPORT_DOCS) {
     }
   })
 
-  app.listen({ port: PG_META_PORT, host: PG_META_HOST }, (err) => {
+  app.listen({ port: PG_META_PORT, host: PG_META_HOST }, (err,address) => {
     if (err) {
       app.log.error({ err }, 'Uncaught error in app, exit(1)')
       process.exit(1)
+    }else{
+      if (isRunningInWSL()) {
+          app.log.info(`[WSL Detected] Server is running. Access from your Windows browser at http://localhost:${PG_META_PORT}`);
+          app.log.info(`(Internal address: ${address})`);
+        } 
     }
     const adminPort = PG_META_PORT + 1
     adminApp.listen({ port: adminPort, host: PG_META_HOST }, (err) => {

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import os from 'os'
 import pgcs from 'pg-connection-string'
 import { FastifyRequest } from 'fastify'
 import { DEFAULT_POOL_CONFIG } from './constants.js'
@@ -47,4 +49,24 @@ export function translateErrorToResponseCode(
     return 408
   }
   return defaultResponseCode
+}
+
+export function isRunningInWSL() {
+  // Check for the presence of a specific file that only exists in WSL
+  if (fs.existsSync('/proc/sys/fs/binfmt_misc/WSLInterop')) {
+    return true;
+  }
+
+  // Check for environment variables (less reliable as a user could set these manually)
+  if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) {
+    return true;
+  }
+  
+  // Check the OS release info (kernel name often contains 'microsoft')
+  const osRelease = os.release();
+  if (osRelease.includes('microsoft') || osRelease.includes('Microsoft')) {
+    return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore (logging improvement for WSL environment)

## What is the current behavior?

When running the server on WSL, the logs incorrectly show:
`Server is running on http://0.0.0.0:1337`
even when the server is actually running on:
`http://localhost:1338`

## What is the new behavior?
Updated logging to correctly detect and display the active host and port on WSL.
Now the console prints the correct URL, improving developer experience when running locally on WSL.
`Server listening on http://localhost:1338`
Feel free to include screenshots if it includes visual changes.

## Additional context
This PR updates src/server/utils.ts to handle environment-specific logging and ensure accurate server address reporting.
Tested on WSL Ubuntu and confirmed working.
Add any other context or screenshots.
