### PR TITLE
fix: function type generation for zero arg and scalar computed fields

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -63,6 +63,7 @@ export const apply = async ({
   const columnsByTableId: Record<number, PostgresColumn[]> = {}
   const tablesNamesByTableId: Record<number, string> = {}
   const relationTypeByIds = new Map<number, (typeof types)[number]>()
+  // group types by id for quicker lookup
   const typesById = new Map<number, (typeof types)[number]>()
   const tablesLike = [...tables, ...foreignTables, ...views, ...materializedViews]
   const tableAndViewNames = new Set<string>()

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -410,7 +410,7 @@ export const apply = async ({
   ) => {
     return fns
       .map(({ fn, inArgs }) => {
-        let argsType = 'never'
+        let argsType = 'Record<PropertyKey, never>'
         let returnType = getFunctionReturnType(schema, fn)
 
         // Check for specific error cases


### PR DESCRIPTION
## Problems

1. Zero arg functions cause columns with same name to be omitted from query types (`never extends T` is always true)
2. Scalar computed fields like `name_translated(products)` are not added to Row types

## Solution

1. Use `Record<PropertyKey, never>` instead of `never` for zero-arg function Args
2. Include functions with single unnamed table/view parameters in filtering logic

## Related

- Closes supabase/supabase-js#1034
- Closes supabase/postgres-meta#1039
