### PR TITLE
fix: map vector type to number[] in TypeScript type generation

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -901,11 +901,12 @@ export const pgTypeToTsType = (
       'timestamp',
       'timestamptz',
       'uuid',
-      'vector',
       'interval',
     ].includes(pgType)
   ) {
     return 'string'
+  } else if (pgType === 'vector') {
+    return 'number[]'
   } else if (['json', 'jsonb'].includes(pgType)) {
     return 'Json'
   } else if (pgType === 'void') {

--- a/test/lib/typegen-typescript.test.ts
+++ b/test/lib/typegen-typescript.test.ts
@@ -1,0 +1,27 @@
+import { expect, test, describe } from 'vitest'
+import { pgTypeToTsType } from '../../src/server/templates/typescript.js'
+
+const mockSchema = { id: 1, name: 'public' } as any
+const mockContext = { types: [], schemas: [], tables: [], views: [] }
+
+describe('pgTypeToTsType', () => {
+  test('maps vector to number[]', () => {
+    expect(pgTypeToTsType(mockSchema, 'vector', mockContext)).toBe('number[]')
+  })
+
+  test('maps _vector to (number[])[]', () => {
+    expect(pgTypeToTsType(mockSchema, '_vector', mockContext)).toBe('(number[])[]')
+  })
+
+  test('maps text to string', () => {
+    expect(pgTypeToTsType(mockSchema, 'text', mockContext)).toBe('string')
+  })
+
+  test('maps bool to boolean', () => {
+    expect(pgTypeToTsType(mockSchema, 'bool', mockContext)).toBe('boolean')
+  })
+
+  test('maps int4 to number', () => {
+    expect(pgTypeToTsType(mockSchema, 'int4', mockContext)).toBe('number')
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
`vector` type in RPC function parameters generates as `string` in TypeScript. The Supabase client requires `number[]` for vector parameters — `JSON.stringify()` does not work as a workaround for RPC functions and causes queries to fail or return zero results.

Fixes #1029

## What is the new behavior?
`vector` type now correctly generates as `number[]`.

Before:
```typescript
match_documents: {
  Args: {
    query_embedding: string  // ❌
  }
}
```

After:
```typescript
match_documents: {
  Args: {
    query_embedding: number[]  // ✅
  }
}
```

## Additional context
`vector` was grouped with string types in `pgTypeToTsType`. Moved it to its own condition returning `number[]`. A unit test for `pgTypeToTsType` is added in `test/lib/typegen-typescript.test.ts` covering `vector → number[]` and `_vector → (number[])[]`.