### PR TITLE
fix: handle empty segments in formatForGoTypeName

### DIFF
--- a/src/server/templates/go.ts
+++ b/src/server/templates/go.ts
@@ -102,7 +102,13 @@ ${compositeTypes
 function formatForGoTypeName(name: string): string {
   return name
     .split(/[^a-zA-Z0-9]/)
-    .map((word) => `${word[0].toUpperCase()}${word.slice(1)}`)
+    .map((word) => {
+      if (word) {
+        return `${word[0].toUpperCase()}${word.slice(1)}`
+      } else {
+        return ''
+      }
+    })
     .join('')
 }
 


### PR DESCRIPTION
Fixes #1056

`formatForGoTypeName` crashes with a TypeError on names starting with non-alphanumeric characters (like `_prisma_migrations`). The split produces an empty string element, and indexing into it gives `undefined`.

Added the same `if (word)` guard that `formatForPyClassName` in `python.ts` already uses.