### PR TITLE
fix: add interval to Go and Swift type maps

### DIFF
--- a/src/server/templates/go.ts
+++ b/src/server/templates/go.ts
@@ -244,6 +244,7 @@ const GO_TYPE_MAP = {
   timetz: 'string',
   timestamp: 'string',
   timestamptz: 'string',
+  interval: 'string',
   uuid: 'string',
   vector: 'string',
 

--- a/src/server/templates/swift.ts
+++ b/src/server/templates/swift.ts
@@ -325,6 +325,7 @@ const pgTypeToSwiftType = (
       'timetz',
       'timestamp',
       'timestamptz',
+      'interval',
       'vector',
     ].includes(pgType)
   ) {

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -5452,21 +5452,21 @@ test('typegen: go', async () => {
     }
 
     type PublicIntervalTestSelect struct {
-      DurationOptional interface{} \`json:"duration_optional"\`
-      DurationRequired interface{} \`json:"duration_required"\`
-      Id               int64       \`json:"id"\`
+      DurationOptional *string \`json:"duration_optional"\`
+      DurationRequired string  \`json:"duration_required"\`
+      Id               int64   \`json:"id"\`
     }
 
     type PublicIntervalTestInsert struct {
-      DurationOptional interface{} \`json:"duration_optional"\`
-      DurationRequired interface{} \`json:"duration_required"\`
-      Id               *int64      \`json:"id"\`
+      DurationOptional *string \`json:"duration_optional"\`
+      DurationRequired string  \`json:"duration_required"\`
+      Id               *int64  \`json:"id"\`
     }
 
     type PublicIntervalTestUpdate struct {
-      DurationOptional interface{} \`json:"duration_optional"\`
-      DurationRequired interface{} \`json:"duration_required"\`
-      Id               *int64      \`json:"id"\`
+      DurationOptional *string \`json:"duration_optional"\`
+      DurationRequired *string \`json:"duration_required"\`
+      Id               *int64  \`json:"id"\`
     }
 
     type PublicCategorySelect struct {
@@ -5745,8 +5745,8 @@ test('typegen: swift', async () => {
         }
       }
       internal struct IntervalTestSelect: Codable, Hashable, Sendable, Identifiable {
-        internal let durationOptional: IntervalSelect?
-        internal let durationRequired: IntervalSelect
+        internal let durationOptional: String?
+        internal let durationRequired: String
         internal let id: Int64
         internal enum CodingKeys: String, CodingKey {
           case durationOptional = "duration_optional"
@@ -5755,8 +5755,8 @@ test('typegen: swift', async () => {
         }
       }
       internal struct IntervalTestInsert: Codable, Hashable, Sendable, Identifiable {
-        internal let durationOptional: IntervalSelect?
-        internal let durationRequired: IntervalSelect
+        internal let durationOptional: String?
+        internal let durationRequired: String
         internal let id: Int64?
         internal enum CodingKeys: String, CodingKey {
           case durationOptional = "duration_optional"
@@ -5765,8 +5765,8 @@ test('typegen: swift', async () => {
         }
       }
       internal struct IntervalTestUpdate: Codable, Hashable, Sendable, Identifiable {
-        internal let durationOptional: IntervalSelect?
-        internal let durationRequired: IntervalSelect?
+        internal let durationOptional: String?
+        internal let durationRequired: String?
         internal let id: Int64?
         internal enum CodingKeys: String, CodingKey {
           case durationOptional = "duration_optional"
@@ -6276,8 +6276,8 @@ test('typegen: swift w/ public access control', async () => {
         }
       }
       public struct IntervalTestSelect: Codable, Hashable, Sendable, Identifiable {
-        public let durationOptional: IntervalSelect?
-        public let durationRequired: IntervalSelect
+        public let durationOptional: String?
+        public let durationRequired: String
         public let id: Int64
         public enum CodingKeys: String, CodingKey {
           case durationOptional = "duration_optional"
@@ -6286,8 +6286,8 @@ test('typegen: swift w/ public access control', async () => {
         }
       }
       public struct IntervalTestInsert: Codable, Hashable, Sendable, Identifiable {
-        public let durationOptional: IntervalSelect?
-        public let durationRequired: IntervalSelect
+        public let durationOptional: String?
+        public let durationRequired: String
         public let id: Int64?
         public enum CodingKeys: String, CodingKey {
           case durationOptional = "duration_optional"
@@ -6296,8 +6296,8 @@ test('typegen: swift w/ public access control', async () => {
         }
       }
       public struct IntervalTestUpdate: Codable, Hashable, Sendable, Identifiable {
-        public let durationOptional: IntervalSelect?
-        public let durationRequired: IntervalSelect?
+        public let durationOptional: String?
+        public let durationRequired: String?
         public let id: Int64?
         public enum CodingKeys: String, CodingKey {
           case durationOptional = "duration_optional"


### PR DESCRIPTION
Fixes #1058

The Go and Swift type generators don't include `interval` in their type maps, so interval columns fall through to `interface{}` (Go) and `AnyJSON` (Swift) instead of `string`/`String`.

TypeScript (#1031) and Python already map interval to string. This adds the same mapping to Go and Swift, plus updates the test snapshots.

Related: #921