### PR TITLE
fix: respect PG_META_DB_PORT when encrypted connection header uses internal 'db' alias

### DIFF
--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -32,9 +32,24 @@ export default async (fastify: FastifyInstance) => {
       const encryptedHeader = request.headers['x-connection-encrypted']?.toString()
       if (encryptedHeader) {
         try {
-          request.headers.pg = CryptoJS.AES.decrypt(encryptedHeader, CRYPTO_KEY)
+          const decrypted = CryptoJS.AES.decrypt(encryptedHeader, CRYPTO_KEY)
             .toString(CryptoJS.enc.Utf8)
             .trim()
+          let resolved = decrypted
+          if (PG_CONNECTION) {
+            try {
+              const decryptedUrl = new URL(decrypted)
+              if (decryptedUrl.hostname === 'db') {
+                const configuredUrl = new URL(PG_CONNECTION)
+                decryptedUrl.hostname = configuredUrl.hostname
+                decryptedUrl.port = configuredUrl.port
+              }
+              resolved = decryptedUrl.toString()
+            } catch {
+              // malformed URL — leave as-is, caught by validation below
+            }
+          }
+          request.headers.pg = resolved
         } catch (e: any) {
           request.log.warn({
             message: 'failed to parse encrypted connstring',

--- a/test/server/ssl.ts
+++ b/test/server/ssl.ts
@@ -126,3 +126,24 @@ test('query with missing host connection string encrypted connection string', as
     }
   `)
 })
+
+test('query with encrypted connection string using internal "db" host respects PG_META_DB_PORT', async () => {
+  const res = await app.inject({
+    method: 'POST',
+    path: '/query',
+    headers: {
+      'x-connection-encrypted': CryptoJS.AES.encrypt(
+        'postgresql://postgres:postgres@db:5432/postgres',
+        CRYPTO_KEY
+      ).toString(),
+    },
+    payload: { query: 'select 1;' },
+  })
+  expect(res.json()).toMatchInlineSnapshot(`
+    [
+      {
+        "?column?": 1,
+      },
+    ]
+  `)
+})


### PR DESCRIPTION
Fixes #1020

In self-hosted Supabase setups, the upstream proxy (Studio/Kong) sends an `x-connection-encrypted` header that decodes to a connection string with `host=db, port=5432` — the default internal Docker service name. This header was used as-is, completely ignoring `PG_META_DB_URL` / `PG_META_DB_PORT`, causing either `ENOTFOUND db` or connections to the wrong port.

When the decrypted connection string uses hostname `db`, this fix substitutes the host and port from `PG_CONNECTION` (built from env vars). The multi-tenant case (encrypted header pointing to an arbitrary external DB) is unaffected.