### PR TITLE
fix: add | null to composite type fields in TypeScript generator

### DIFF
--- a/src/server/templates/python.ts
+++ b/src/server/templates/python.ts
@@ -198,6 +198,20 @@ class PythonEnum implements Serializable {
   }
 }
 
+class PythonDomain implements Serializable {
+  name: string
+  py_type: PythonType
+
+  constructor(name: string, schema: string, py_type: PythonType) {
+    this.name = `${formatForPyClassName(schema)}${formatForPyClassName(name)}`
+    this.py_type = py_type
+  }
+
+  serialize(): string {
+    return `${this.name}: TypeAlias = ${this.py_type.serialize()}`
+  }
+}
+
 type PythonType = PythonListType | PythonSimpleType
 
 class PythonSimpleType implements Serializable {
@@ -327,6 +341,7 @@ const PY_TYPE_MAP: Record<string, string> = {
   bool: 'bool',
 
   // Numbers
+  int: 'int',
   int2: 'int',
   int4: 'int',
   int8: 'int',

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -719,17 +719,14 @@ export type Database = {
                           const type = typesById.get(type_id)
                           let tsType = 'unknown'
                           if (type) {
-                            tsType = `${generateNullableUnionTsType(
-                              pgTypeToTsType(schema, type.name, {
-                                types,
-                                schemas,
-                                tables,
-                                views,
-                              }),
-                              true
-                            )}`
+                            tsType = pgTypeToTsType(schema, type.name, {
+                              types,
+                              schemas,
+                              tables,
+                              views,
+                            })
                           }
-                          return `${JSON.stringify(name)}: ${tsType}`
+                          return `${JSON.stringify(name)}: ${tsType} | null`
                         })}
                       }`
                   )

--- a/test/db/00-init.sql
+++ b/test/db/00-init.sql
@@ -502,8 +502,14 @@ AS $$
   SELECT interval_test_row.duration_required * 2;
 $$;
 
-CREATE DOMAIN one_to_ten AS int CHECK (VALUE >= 1 AND VALUE <= 10);
+CREATE DOMAIN public.one_to_ten AS int CHECK (VALUE >= 1 AND VALUE <= 10);
+
 CREATE TYPE composite_type_with_domain_attribute AS (
   name text,
-  score one_to_ten
+  score public.one_to_ten
+);
+
+CREATE TYPE composite_type_with_int_attribute AS (
+  a int,
+  b int
 );

--- a/test/db/00-init.sql
+++ b/test/db/00-init.sql
@@ -501,3 +501,9 @@ STABLE
 AS $$
   SELECT interval_test_row.duration_required * 2;
 $$;
+
+CREATE DOMAIN one_to_ten AS int CHECK (VALUE >= 1 AND VALUE <= 10);
+CREATE TYPE composite_type_with_domain_attribute AS (
+  name text,
+  score one_to_ten
+);

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -1060,6 +1060,10 @@ test('typegen: typescript', async () => {
           composite_type_with_array_attribute: {
             my_text_array: string[] | null
           }
+          composite_type_with_domain_attribute: {
+            name: string | null
+            score: unknown | null
+          }
           composite_type_with_record_attribute: {
             todo: Database["public"]["Tables"]["todos"]["Row"] | null
           }
@@ -2285,6 +2289,10 @@ test('typegen w/ one-to-one relationships', async () => {
           composite_type_with_array_attribute: {
             my_text_array: string[] | null
           }
+          composite_type_with_domain_attribute: {
+            name: string | null
+            score: unknown | null
+          }
           composite_type_with_record_attribute: {
             todo: Database["public"]["Tables"]["todos"]["Row"] | null
           }
@@ -3509,6 +3517,10 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
         CompositeTypes: {
           composite_type_with_array_attribute: {
             my_text_array: string[] | null
+          }
+          composite_type_with_domain_attribute: {
+            name: string | null
+            score: unknown | null
           }
           composite_type_with_record_attribute: {
             todo: Database["public"]["Tables"]["todos"]["Row"] | null
@@ -4739,6 +4751,10 @@ test('typegen: typescript w/ postgrestVersion', async () => {
         CompositeTypes: {
           composite_type_with_array_attribute: {
             my_text_array: string[] | null
+          }
+          composite_type_with_domain_attribute: {
+            name: string | null
+            score: unknown | null
           }
           composite_type_with_record_attribute: {
             todo: Database["public"]["Tables"]["todos"]["Row"] | null

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -5593,6 +5593,11 @@ test('typegen: go', async () => {
     type PublicCompositeTypeWithDomainAttribute struct {
       Name  string      \`json:"name"\`
       Score interface{} \`json:"score"\`
+    }
+
+    type PublicCompositeTypeWithIntAttribute struct {
+      A interface{} \`json:"a"\`
+      B interface{} \`json:"b"\`
     }"
   `)
 })
@@ -6120,6 +6125,14 @@ test('typegen: swift', async () => {
         internal enum CodingKeys: String, CodingKey {
           case Name = "name"
           case Score = "score"
+        }
+      }
+      internal struct CompositeTypeWithIntAttribute: Codable, Hashable, Sendable {
+        internal let A: AnyJSON
+        internal let B: AnyJSON
+        internal enum CodingKeys: String, CodingKey {
+          case A = "a"
+          case B = "b"
         }
       }
       internal struct CompositeTypeWithRecordAttribute: Codable, Hashable, Sendable {
@@ -6661,6 +6674,14 @@ test('typegen: swift w/ public access control', async () => {
           case Score = "score"
         }
       }
+      public struct CompositeTypeWithIntAttribute: Codable, Hashable, Sendable {
+        public let A: AnyJSON
+        public let B: AnyJSON
+        public enum CodingKeys: String, CodingKey {
+          case A = "a"
+          case B = "b"
+        }
+      }
       public struct CompositeTypeWithRecordAttribute: Codable, Hashable, Sendable {
         public let Todo: TodosSelect
         public enum CodingKeys: String, CodingKey {
@@ -6698,8 +6719,6 @@ test('typegen: python', async () => {
     PublicUserStatus: TypeAlias = Literal["ACTIVE", "INACTIVE"]
 
     PublicMemeStatus: TypeAlias = Literal["new", "old", "retired"]
-
-    PublicOneToTen: TypeAlias = int
 
     class PublicUsers(BaseModel):
         decimal: Optional[float] = Field(alias="decimal")
@@ -6946,7 +6965,11 @@ test('typegen: python', async () => {
 
     class PublicCompositeTypeWithDomainAttribute(BaseModel):
         name: str = Field(alias="name")
-        score: PublicOneToTen = Field(alias="score")"
+        score: PublicOneToTen = Field(alias="score")
+
+    class PublicCompositeTypeWithIntAttribute(BaseModel):
+        a: int = Field(alias="a")
+        b: int = Field(alias="b")"
   `)
 })
 

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -1064,6 +1064,10 @@ test('typegen: typescript', async () => {
             name: string | null
             score: unknown | null
           }
+          composite_type_with_int_attribute: {
+            a: number | null
+            b: number | null
+          }
           composite_type_with_record_attribute: {
             todo: Database["public"]["Tables"]["todos"]["Row"] | null
           }
@@ -2293,6 +2297,10 @@ test('typegen w/ one-to-one relationships', async () => {
             name: string | null
             score: unknown | null
           }
+          composite_type_with_int_attribute: {
+            a: number | null
+            b: number | null
+          }
           composite_type_with_record_attribute: {
             todo: Database["public"]["Tables"]["todos"]["Row"] | null
           }
@@ -3521,6 +3529,10 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
           composite_type_with_domain_attribute: {
             name: string | null
             score: unknown | null
+          }
+          composite_type_with_int_attribute: {
+            a: number | null
+            b: number | null
           }
           composite_type_with_record_attribute: {
             todo: Database["public"]["Tables"]["todos"]["Row"] | null
@@ -4756,6 +4768,10 @@ test('typegen: typescript w/ postgrestVersion', async () => {
             name: string | null
             score: unknown | null
           }
+          composite_type_with_int_attribute: {
+            a: number | null
+            b: number | null
+          }
           composite_type_with_record_attribute: {
             todo: Database["public"]["Tables"]["todos"]["Row"] | null
           }
@@ -5572,6 +5588,11 @@ test('typegen: go', async () => {
 
     type PublicCompositeTypeWithRecordAttribute struct {
       Todo interface{} \`json:"todo"\`
+    }
+
+    type PublicCompositeTypeWithDomainAttribute struct {
+      Name  string      \`json:"name"\`
+      Score interface{} \`json:"score"\`
     }"
   `)
 })
@@ -6091,6 +6112,14 @@ test('typegen: swift', async () => {
         internal let MyTextArray: AnyJSON
         internal enum CodingKeys: String, CodingKey {
           case MyTextArray = "my_text_array"
+        }
+      }
+      internal struct CompositeTypeWithDomainAttribute: Codable, Hashable, Sendable {
+        internal let Name: String
+        internal let Score: OneToTenSelect
+        internal enum CodingKeys: String, CodingKey {
+          case Name = "name"
+          case Score = "score"
         }
       }
       internal struct CompositeTypeWithRecordAttribute: Codable, Hashable, Sendable {
@@ -6624,6 +6653,14 @@ test('typegen: swift w/ public access control', async () => {
           case MyTextArray = "my_text_array"
         }
       }
+      public struct CompositeTypeWithDomainAttribute: Codable, Hashable, Sendable {
+        public let Name: String
+        public let Score: OneToTenSelect
+        public enum CodingKeys: String, CodingKey {
+          case Name = "name"
+          case Score = "score"
+        }
+      }
       public struct CompositeTypeWithRecordAttribute: Codable, Hashable, Sendable {
         public let Todo: TodosSelect
         public enum CodingKeys: String, CodingKey {
@@ -6661,6 +6698,8 @@ test('typegen: python', async () => {
     PublicUserStatus: TypeAlias = Literal["ACTIVE", "INACTIVE"]
 
     PublicMemeStatus: TypeAlias = Literal["new", "old", "retired"]
+
+    PublicOneToTen: TypeAlias = int
 
     class PublicUsers(BaseModel):
         decimal: Optional[float] = Field(alias="decimal")
@@ -6903,7 +6942,11 @@ test('typegen: python', async () => {
         my_text_array: List[str] = Field(alias="my_text_array")
 
     class PublicCompositeTypeWithRecordAttribute(BaseModel):
-        todo: PublicTodos = Field(alias="todo")"
+        todo: PublicTodos = Field(alias="todo")
+
+    class PublicCompositeTypeWithDomainAttribute(BaseModel):
+        name: str = Field(alias="name")
+        score: PublicOneToTen = Field(alias="score")"
   `)
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
Composite type fields were not emitting `| null` in the generated TypeScript types, making them incorrectly non-nullable.

Fixes #763

## What is the new behavior?
All composite type fields now emit `| null`, including domain-typed fields which previously fell through to `unknown` without `| null`.

Before:
```ts
CompositeTypes: {
  t: {
    a: number
    b: unknown
  }
}
```

After:
```ts
CompositeTypes: {
  t: {
    a: number | null
    b: unknown | null
  }
}
```

## Additional context
Per the PostgreSQL docs, composite type fields cannot have NOT NULL constraints, so every field is inherently nullable.