### PR TITLE
chore: use literal for limits and offsets

### DIFF
--- a/src/lib/sql/column_privileges.sql.ts
+++ b/src/lib/sql/column_privileges.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilter } from './common.js'
 
 export const COLUMN_PRIVILEGES_SQL = (
@@ -152,6 +153,6 @@ group by column_id,
          nc.nspname,
          x.relname,
          x.attname
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/columns.sql.ts
+++ b/src/lib/sql/columns.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilter } from './common.js'
 
 export const COLUMNS_SQL = (
@@ -124,6 +125,6 @@ WHERE
       'SELECT, INSERT, UPDATE, REFERENCES'
     )
   )
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/config.sql.ts
+++ b/src/lib/sql/config.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
 
 export const CONFIG_SQL = (props: SQLQueryPropsWithSchemaFilterAndIdsFilter) => /* SQL */ `
@@ -26,6 +27,6 @@ FROM
 ORDER BY
   category,
   name
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/extensions.sql.ts
+++ b/src/lib/sql/extensions.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryProps } from './common.js'
 
 export const EXTENSIONS_SQL = (props: SQLQueryProps & { nameFilter?: string }) => /* SQL */ `
@@ -14,6 +15,6 @@ FROM
 WHERE
   true
   ${props.nameFilter ? `AND e.name ${props.nameFilter}` : ''}
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/foreign_tables.sql.ts
+++ b/src/lib/sql/foreign_tables.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryProps } from './common.js'
 
 export const FOREIGN_TABLES_SQL = (
@@ -20,6 +21,6 @@ WHERE
   ${props.idsFilter ? `c.oid ${props.idsFilter} AND` : ''}
   ${props.tableIdentifierFilter ? `(n.nspname || '.' || c.relname) ${props.tableIdentifierFilter} AND` : ''}
   c.relkind = 'f'
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/functions.sql.ts
+++ b/src/lib/sql/functions.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
 
 export const FUNCTIONS_SQL = (
@@ -150,6 +151,6 @@ from
     group by
       t1.oid
   ) f_args on f_args.oid = f.oid
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/indexes.sql.ts
+++ b/src/lib/sql/indexes.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
 
 export const INDEXES_SQL = (props: SQLQueryPropsWithSchemaFilterAndIdsFilter) => /* SQL */ `
@@ -45,6 +46,6 @@ SELECT
     ${props.idsFilter ? `AND idx.indexrelid ${props.idsFilter}` : ''}
   GROUP BY
     idx.indexrelid, idx.indrelid, n.nspname, idx.indnatts, idx.indnkeyatts, idx.indisunique, idx.indisprimary, idx.indisexclusion, idx.indimmediate, idx.indisclustered, idx.indisvalid, idx.indcheckxmin, idx.indisready, idx.indislive, idx.indisreplident, idx.indkey, idx.indcollation, idx.indclass, idx.indoption, idx.indexprs, idx.indpred, ix.indexdef, am.amname
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/materialized_views.sql.ts
+++ b/src/lib/sql/materialized_views.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
 
 export const MATERIALIZED_VIEWS_SQL = (
@@ -19,6 +20,6 @@ where
   ${props.idsFilter ? `c.oid ${props.idsFilter} AND` : ''}
   ${props.materializedViewIdentifierFilter ? `(n.nspname || '.' || c.relname) ${props.materializedViewIdentifierFilter} AND` : ''}
   c.relkind = 'm'
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/policies.sql.ts
+++ b/src/lib/sql/policies.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
 
 export const POLICIES_SQL = (
@@ -49,6 +50,6 @@ WHERE
   ${props.schemaFilter ? `n.nspname ${props.schemaFilter}` : 'true'}
   ${props.idsFilter ? `AND pol.oid ${props.idsFilter}` : ''}
   ${props.functionNameIdentifierFilter ? `AND (c.relname || '.' || pol.polname) ${props.functionNameIdentifierFilter}` : ''}
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/publications.sql.ts
+++ b/src/lib/sql/publications.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithIdsFilter } from './common.js'
 
 export const PUBLICATIONS_SQL = (
@@ -42,6 +43,6 @@ FROM
 WHERE
   ${props.idsFilter ? `p.oid ${props.idsFilter}` : 'true'}
   ${props.nameFilter ? `AND p.pubname ${props.nameFilter}` : ''}
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/roles.sql.ts
+++ b/src/lib/sql/roles.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithIdsFilter } from './common.js'
 
 export const ROLES_SQL = (
@@ -39,6 +40,6 @@ WHERE
   -- The pg_ prefix is also reserved.
   ${!props.includeDefaultRoles ? `AND NOT pg_catalog.starts_with(rolname, 'pg_')` : ''}
   ${props.nameFilter ? `AND rolname ${props.nameFilter}` : ''}
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/schemas.sql.ts
+++ b/src/lib/sql/schemas.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryProps } from './common.js'
 
 export const SCHEMAS_SQL = (
@@ -22,6 +23,6 @@ where
   )
   and not pg_catalog.starts_with(n.nspname, 'pg_temp_')
   and not pg_catalog.starts_with(n.nspname, 'pg_toast_temp_')
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/table.sql.ts
+++ b/src/lib/sql/table.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
 
 export const TABLES_SQL = (
@@ -105,6 +106,6 @@ group by
   c.relreplident,
   nc.nspname,
   pk.primary_keys
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/table_privileges.sql.ts
+++ b/src/lib/sql/table_privileges.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
 
 export const TABLE_PRIVILEGES_SQL = (
@@ -83,6 +84,6 @@ group by
   nc.nspname,
   c.relname,
   c.relkind
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/triggers.sql.ts
+++ b/src/lib/sql/triggers.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
 
 export const TRIGGERS_SQL = (
@@ -63,6 +64,6 @@ GROUP BY
   is_t.action_timing,
   pg_p.proname,
   pg_n.nspname
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/types.sql.ts
+++ b/src/lib/sql/types.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
 
 export const TYPES_SQL = (
@@ -68,6 +69,6 @@ from
       }
       ${props.schemaFilter ? `and n.nspname ${props.schemaFilter}` : ''}
       ${props.idsFilter ? `and t.oid ${props.idsFilter}` : ''}
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `

--- a/src/lib/sql/views.sql.ts
+++ b/src/lib/sql/views.sql.ts
@@ -1,3 +1,4 @@
+import { literal } from 'pg-format'
 import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
 
 export const VIEWS_SQL = (
@@ -20,6 +21,6 @@ WHERE
   ${props.idsFilter ? `c.oid ${props.idsFilter} AND` : ''}
   ${props.viewIdentifierFilter ? `(n.nspname || '.' || c.relname) ${props.viewIdentifierFilter} AND` : ''}
   c.relkind = 'v'
-${props.limit ? `limit ${props.limit}` : ''}
-${props.offset ? `offset ${props.offset}` : ''}
+${props.limit ? `limit ${literal(props.limit)}` : ''}
+${props.offset ? `offset ${literal(props.offset)}` : ''}
 `


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Limits and offsets are typed as Number but are treated as string in SQL template generation

## What is the new behavior?

Treats these as literals so the SQL will always be correct / valid.

## Additional context

Add any other context or screenshots.
