### PR TITLE
fix: type ROWS 1 set-returning functions as arrays

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -220,7 +220,7 @@ export const apply = async ({
       fn.return_type_id
     )
     const returnsSetOfTable = fn.is_set_returning_function && fn.return_type_relation_id !== null
-    const returnsMultipleRows = fn.prorows !== null && fn.prorows > 1
+    const returnsMultipleRows = fn.is_set_returning_function
     // Case 1: if the function returns a table, we need to add SetofOptions to allow selecting sub fields of the table
     // Those can be used in rpc to select sub fields of a table
     if (returnTableName) {

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -1,6 +1,4 @@
-import CryptoJS from 'crypto-js'
 import { expect, test } from 'vitest'
-import { CRYPTO_KEY } from '../../src/server/constants'
 import { app } from './utils'
 
 test('typegen: typescript', async () => {
@@ -6968,21 +6966,7 @@ test('typegen: python w/ excluded/included schemas', async () => {
 })
 
 test('typegen: typescript keeps ROWS 1 set-returning functions as arrays', async () => {
-  const connectionString = process.env.PG_META_TEST_CONNECTION_STRING
-  const encryptedConnection = connectionString
-    ? CryptoJS.AES.encrypt(connectionString, CRYPTO_KEY).toString()
-    : undefined
-  const { body } = await app.inject({
-    method: 'GET',
-    path: '/generators/typescript',
-    ...(encryptedConnection
-      ? {
-          headers: {
-            'x-connection-encrypted': encryptedConnection,
-          },
-        }
-      : {}),
-  })
+  const { body } = await app.inject({ method: 'GET', path: '/generators/typescript' })
 
   const setofRowsOneMatch = body.match(
     /function_using_setof_rows_one:[\s\S]*?function_using_table_returns:/

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -1,4 +1,6 @@
+import CryptoJS from 'crypto-js'
 import { expect, test } from 'vitest'
+import { CRYPTO_KEY } from '../../src/server/constants'
 import { app } from './utils'
 
 test('typegen: typescript', async () => {
@@ -6963,4 +6965,38 @@ test('typegen: python w/ excluded/included schemas', async () => {
       },
     })
   }
+})
+
+test('typegen: typescript keeps ROWS 1 set-returning functions as arrays', async () => {
+  const connectionString = process.env.PG_META_TEST_CONNECTION_STRING
+  const encryptedConnection = connectionString
+    ? CryptoJS.AES.encrypt(connectionString, CRYPTO_KEY).toString()
+    : undefined
+  const { body } = await app.inject({
+    method: 'GET',
+    path: '/generators/typescript',
+    ...(encryptedConnection
+      ? {
+          headers: {
+            'x-connection-encrypted': encryptedConnection,
+          },
+        }
+      : {}),
+  })
+
+  const setofRowsOneMatch = body.match(
+    /function_using_setof_rows_one:[\s\S]*?function_using_table_returns:/
+  )
+  expect(setofRowsOneMatch).not.toBeNull()
+  expect(setofRowsOneMatch?.[0]).toContain('}[]')
+  expect(setofRowsOneMatch?.[0]).toContain('isOneToOne: false')
+  expect(setofRowsOneMatch?.[0]).toContain('isSetofReturn: true')
+
+  const tableReturnsMatch = body.match(
+    /function_using_table_returns:[\s\S]*?get_composite_type_data:/
+  )
+  expect(tableReturnsMatch).not.toBeNull()
+  expect(tableReturnsMatch?.[0]).not.toContain('}[]')
+  expect(tableReturnsMatch?.[0]).toContain('isOneToOne: true')
+  expect(tableReturnsMatch?.[0]).toContain('isSetofReturn: false')
 })

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -670,7 +670,7 @@ test('typegen: typescript', async () => {
               details: string | null
               id: number
               "user-id": number
-            }
+            }[]
             SetofOptions: {
               from: "users"
               to: "todos"
@@ -711,7 +711,7 @@ test('typegen: typescript', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "*"
                   to: "user_todos_summary_view"
@@ -727,7 +727,7 @@ test('typegen: typescript', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "users"
                   to: "user_todos_summary_view"
@@ -745,7 +745,7 @@ test('typegen: typescript', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "users_view"
                   to: "user_todos_summary_view"
@@ -759,7 +759,7 @@ test('typegen: typescript', async () => {
               details: string | null
               id: number
               "user-id": number
-            }
+            }[]
             SetofOptions: {
               from: "todos_matview"
               to: "todos"
@@ -848,7 +848,7 @@ test('typegen: typescript', async () => {
               id: number
               previous_value: Json | null
               user_id: number | null
-            }
+            }[]
             SetofOptions: {
               from: "users"
               to: "users_audit"
@@ -1895,7 +1895,7 @@ test('typegen w/ one-to-one relationships', async () => {
               details: string | null
               id: number
               "user-id": number
-            }
+            }[]
             SetofOptions: {
               from: "users"
               to: "todos"
@@ -1936,7 +1936,7 @@ test('typegen w/ one-to-one relationships', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "*"
                   to: "user_todos_summary_view"
@@ -1952,7 +1952,7 @@ test('typegen w/ one-to-one relationships', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "users"
                   to: "user_todos_summary_view"
@@ -1970,7 +1970,7 @@ test('typegen w/ one-to-one relationships', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "users_view"
                   to: "user_todos_summary_view"
@@ -1984,7 +1984,7 @@ test('typegen w/ one-to-one relationships', async () => {
               details: string | null
               id: number
               "user-id": number
-            }
+            }[]
             SetofOptions: {
               from: "todos_matview"
               to: "todos"
@@ -2073,7 +2073,7 @@ test('typegen w/ one-to-one relationships', async () => {
               id: number
               previous_value: Json | null
               user_id: number | null
-            }
+            }[]
             SetofOptions: {
               from: "users"
               to: "users_audit"
@@ -3120,7 +3120,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
               details: string | null
               id: number
               "user-id": number
-            }
+            }[]
             SetofOptions: {
               from: "users"
               to: "todos"
@@ -3161,7 +3161,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "*"
                   to: "user_todos_summary_view"
@@ -3177,7 +3177,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "users"
                   to: "user_todos_summary_view"
@@ -3195,7 +3195,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "users_view"
                   to: "user_todos_summary_view"
@@ -3209,7 +3209,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
               details: string | null
               id: number
               "user-id": number
-            }
+            }[]
             SetofOptions: {
               from: "todos_matview"
               to: "todos"
@@ -3298,7 +3298,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
               id: number
               previous_value: Json | null
               user_id: number | null
-            }
+            }[]
             SetofOptions: {
               from: "users"
               to: "users_audit"
@@ -4350,7 +4350,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
               details: string | null
               id: number
               "user-id": number
-            }
+            }[]
             SetofOptions: {
               from: "users"
               to: "todos"
@@ -4391,7 +4391,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "*"
                   to: "user_todos_summary_view"
@@ -4407,7 +4407,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "users"
                   to: "user_todos_summary_view"
@@ -4425,7 +4425,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
                   user_id: number | null
                   user_name: string | null
                   user_status: Database["public"]["Enums"]["user_status"] | null
-                }
+                }[]
                 SetofOptions: {
                   from: "users_view"
                   to: "user_todos_summary_view"
@@ -4439,7 +4439,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
               details: string | null
               id: number
               "user-id": number
-            }
+            }[]
             SetofOptions: {
               from: "todos_matview"
               to: "todos"
@@ -4528,7 +4528,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
               id: number
               previous_value: Json | null
               user_id: number | null
-            }
+            }[]
             SetofOptions: {
               from: "users"
               to: "users_audit"

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -674,7 +674,7 @@ test('typegen: typescript', async () => {
             SetofOptions: {
               from: "users"
               to: "todos"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -715,7 +715,7 @@ test('typegen: typescript', async () => {
                 SetofOptions: {
                   from: "*"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -731,7 +731,7 @@ test('typegen: typescript', async () => {
                 SetofOptions: {
                   from: "users"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -749,7 +749,7 @@ test('typegen: typescript', async () => {
                 SetofOptions: {
                   from: "users_view"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -763,7 +763,7 @@ test('typegen: typescript', async () => {
             SetofOptions: {
               from: "todos_matview"
               to: "todos"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -852,7 +852,7 @@ test('typegen: typescript', async () => {
             SetofOptions: {
               from: "users"
               to: "users_audit"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -1899,7 +1899,7 @@ test('typegen w/ one-to-one relationships', async () => {
             SetofOptions: {
               from: "users"
               to: "todos"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -1940,7 +1940,7 @@ test('typegen w/ one-to-one relationships', async () => {
                 SetofOptions: {
                   from: "*"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -1956,7 +1956,7 @@ test('typegen w/ one-to-one relationships', async () => {
                 SetofOptions: {
                   from: "users"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -1974,7 +1974,7 @@ test('typegen w/ one-to-one relationships', async () => {
                 SetofOptions: {
                   from: "users_view"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -1988,7 +1988,7 @@ test('typegen w/ one-to-one relationships', async () => {
             SetofOptions: {
               from: "todos_matview"
               to: "todos"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -2077,7 +2077,7 @@ test('typegen w/ one-to-one relationships', async () => {
             SetofOptions: {
               from: "users"
               to: "users_audit"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -3124,7 +3124,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
             SetofOptions: {
               from: "users"
               to: "todos"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -3165,7 +3165,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
                 SetofOptions: {
                   from: "*"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -3181,7 +3181,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
                 SetofOptions: {
                   from: "users"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -3199,7 +3199,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
                 SetofOptions: {
                   from: "users_view"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -3213,7 +3213,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
             SetofOptions: {
               from: "todos_matview"
               to: "todos"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -3302,7 +3302,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
             SetofOptions: {
               from: "users"
               to: "users_audit"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -4354,7 +4354,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
             SetofOptions: {
               from: "users"
               to: "todos"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -4395,7 +4395,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
                 SetofOptions: {
                   from: "*"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -4411,7 +4411,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
                 SetofOptions: {
                   from: "users"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -4429,7 +4429,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
                 SetofOptions: {
                   from: "users_view"
                   to: "user_todos_summary_view"
-                  isOneToOne: true
+                  isOneToOne: false
                   isSetofReturn: true
                 }
               }
@@ -4443,7 +4443,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
             SetofOptions: {
               from: "todos_matview"
               to: "todos"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }
@@ -4532,7 +4532,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
             SetofOptions: {
               from: "users"
               to: "users_audit"
-              isOneToOne: true
+              isOneToOne: false
               isSetofReturn: true
             }
           }


### PR DESCRIPTION
## Problem

TypeScript type generation used `prorows > 1` to decide whether an RPC return type should be an array.

`prorows` comes from PostgreSQL `ROWS n`, which is a planner estimate. It does not change the runtime shape of a set-returning function. A function declared as `RETURNS SETOF ... ROWS 1` still returns a list through PostgREST.

That made generated RPC types collapse `RETURNS SETOF ... ROWS 1` functions to a single object.

## Change

Use `is_set_returning_function` as the return-shape signal for generated TypeScript RPC types.

This keeps scalar and table-returning functions on the existing single-object path, while `RETURNS SETOF ... ROWS 1` now gets an array `Returns` type.

The existing snapshots now reflect the corrected `Returns` and `SetofOptions.isOneToOne` behavior for the `ROWS 1` fixtures. This PR also adds a dedicated regression test that contrasts the two relevant cases directly:

- `function_using_table_returns` stays a single object
- `function_using_setof_rows_one` still generates an array even with `ROWS 1`

## Issue

Addresses supabase/supabase#46525.

## Validation

- `npm run check`
- `npx prettier --check src/server/templates/typescript.ts test/server/typegen.ts`
- `npx -p node@20 node ./node_modules/vitest/vitest.mjs run test/index.test.ts -t "typegen: typescript keeps ROWS 1 set-returning functions as arrays" --reporter verbose`
