### PR TITLE
fix: escape replica_identity_index with ident()

### DIFF
--- a/src/lib/PostgresMetaTables.ts
+++ b/src/lib/PostgresMetaTables.ts
@@ -171,7 +171,7 @@ export default class PostgresMetaTables {
     if (replica_identity === undefined) {
       // skip
     } else if (replica_identity === 'INDEX') {
-      replicaSql = `${alter} REPLICA IDENTITY USING INDEX ${replica_identity_index};`
+      replicaSql = `${alter} REPLICA IDENTITY USING INDEX ${ident(replica_identity_index)};`
     } else {
       replicaSql = `${alter} REPLICA IDENTITY ${replica_identity};`
     }

--- a/test/lib/tables.ts
+++ b/test/lib/tables.ts
@@ -577,3 +577,25 @@ test('composite primary keys preserve order', async () => {
 
   await pgMeta.tables.remove(res.data!.id)
 })
+
+test('update replica identity using an index whose name needs quoting', async () => {
+  // The index name contains a space and uppercase letters, so it only resolves
+  // if it is passed through ident(). An unquoted name would make the generated
+  // ALTER TABLE ... USING INDEX statement invalid.
+  await pgMeta.query(`
+    CREATE TABLE public.t_replica_idx (id int8 NOT NULL);
+    CREATE UNIQUE INDEX "Weird Index" ON public.t_replica_idx (id);
+  `)
+  const { data: tables } = await pgMeta.tables.list()
+  const tableId = tables!.find((t) => t.name === 't_replica_idx')!.id
+
+  const res = await pgMeta.tables.update(tableId, {
+    replica_identity: 'INDEX',
+    replica_identity_index: 'Weird Index',
+  })
+
+  expect(res.error).toBeNull()
+  expect(res.data!.replica_identity).toBe('INDEX')
+
+  await pgMeta.tables.remove(tableId)
+})


### PR DESCRIPTION
`tables.update()` interpolates `replica_identity_index` into the `REPLICA IDENTITY USING INDEX` clause without `ident()`, unlike every other identifier in the same function. Index names that need quoting produce invalid SQL, and the value reaches the database unescaped. This wraps it with `ident()`, matching the rest of the function and the `packages/pg-meta` sibling.

Added a test that updates the replica identity using an index whose name needs quoting. It fails without the change and passes with it.

Closes #1079
