### PR TITLE
feat(typegen): add bigint_as option for int8/numeric TypeScript generation

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -50,6 +50,8 @@ export const GENERATE_TYPES_SWIFT_ACCESS_CONTROL = process.env
   .PG_META_GENERATE_TYPES_SWIFT_ACCESS_CONTROL
   ? (process.env.PG_META_GENERATE_TYPES_SWIFT_ACCESS_CONTROL as AccessControl)
   : 'internal'
+export const GENERATE_TYPES_BIGINT_AS = (process.env.PG_META_GENERATE_TYPES_BIGINT_AS ??
+  'number') as 'number' | 'string' | 'bigint'
 
 // json/jsonb/text types
 export const VALID_UNNAMED_FUNCTION_ARG_TYPES = new Set([114, 3802, 25])

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -50,8 +50,7 @@ export const GENERATE_TYPES_SWIFT_ACCESS_CONTROL = process.env
   .PG_META_GENERATE_TYPES_SWIFT_ACCESS_CONTROL
   ? (process.env.PG_META_GENERATE_TYPES_SWIFT_ACCESS_CONTROL as AccessControl)
   : 'internal'
-export const GENERATE_TYPES_BIGINT_AS = (process.env.PG_META_GENERATE_TYPES_BIGINT_AS ??
-  'number') as 'number' | 'string' | 'bigint'
+export const GENERATE_TYPES_BIGINT_AS = process.env.PG_META_GENERATE_TYPES_BIGINT_AS ?? 'number'
 
 // json/jsonb/text types
 export const VALID_UNNAMED_FUNCTION_ARG_TYPES = new Set([114, 3802, 25])

--- a/src/server/routes/generators/typescript.ts
+++ b/src/server/routes/generators/typescript.ts
@@ -12,6 +12,7 @@ export default async (fastify: FastifyInstance) => {
       included_schemas?: string
       detect_one_to_one_relationships?: string
       postgrest_version?: string
+      bigint_as?: 'number' | 'string' | 'bigint'
     }
   }>('/', async (request, reply) => {
     const config = createConnectionConfig(request)
@@ -21,6 +22,7 @@ export default async (fastify: FastifyInstance) => {
       request.query.included_schemas?.split(',').map((schema) => schema.trim()) ?? []
     const detectOneToOneRelationships = request.query.detect_one_to_one_relationships === 'true'
     const postgrestVersion = request.query.postgrest_version
+    const bigintAs = request.query.bigint_as ?? 'number'
 
     const pgMeta: PostgresMeta = new PostgresMeta(config)
     const { data: generatorMeta, error: generatorMetaError } = await getGeneratorMetadata(pgMeta, {
@@ -37,6 +39,7 @@ export default async (fastify: FastifyInstance) => {
       ...generatorMeta,
       detectOneToOneRelationships,
       postgrestVersion,
+      bigintAs,
     })
   })
 }

--- a/src/server/routes/generators/typescript.ts
+++ b/src/server/routes/generators/typescript.ts
@@ -12,7 +12,7 @@ export default async (fastify: FastifyInstance) => {
       included_schemas?: string
       detect_one_to_one_relationships?: string
       postgrest_version?: string
-      bigint_as?: 'number' | 'string' | 'bigint'
+      bigint_as?: string
     }
   }>('/', async (request, reply) => {
     const config = createConnectionConfig(request)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_POOL_CONFIG,
   EXPORT_DOCS,
   GENERATE_TYPES,
+  GENERATE_TYPES_BIGINT_AS,
   GENERATE_TYPES_DETECT_ONE_TO_ONE_RELATIONSHIPS,
   GENERATE_TYPES_INCLUDED_SCHEMAS,
   GENERATE_TYPES_SWIFT_ACCESS_CONTROL,
@@ -136,7 +137,7 @@ async function getTypeOutput(): Promise<string | null> {
 
   switch (GENERATE_TYPES?.toLowerCase()) {
     case 'typescript':
-      return await applyTypescriptTemplate(config)
+      return await applyTypescriptTemplate({ ...config, bigintAs: GENERATE_TYPES_BIGINT_AS })
     case 'swift':
       return await applySwiftTemplate({
         ...config,

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -35,7 +35,7 @@ export const apply = async ({
 }: GeneratorMetadata & {
   detectOneToOneRelationships: boolean
   postgrestVersion?: string
-  bigintAs?: 'number' | 'string' | 'bigint'
+  bigintAs?: string
 }): Promise<string> => {
   schemas.sort((a, b) => a.name.localeCompare(b.name))
   relationships.sort(
@@ -511,7 +511,8 @@ export const apply = async ({
       schemas: PostgresSchema[]
       tables: PostgresTable[]
       views: PostgresView[]
-      bigintAs: 'number' | 'string' | 'bigint'
+      bigintAs: string
+      isWriteColumn?: boolean
     }
   ) {
     return `${JSON.stringify(column.name)}${column.is_optional ? '?' : ''}: ${generateNullableUnionTsType(pgTypeToTsType(schema, column.format, context), column.is_nullable)}`
@@ -574,7 +575,7 @@ export type Database = {
                             column.is_identity ||
                             column.default_value !== null,
                         },
-                        { types, schemas, tables, views, bigintAs }
+                        { types, schemas, tables, views, bigintAs, isWriteColumn: true }
                       )
                     })}
                   }
@@ -592,7 +593,7 @@ export type Database = {
                           is_nullable: column.is_nullable,
                           is_optional: true,
                         },
-                        { types, schemas, tables, views, bigintAs }
+                        { types, schemas, tables, views, bigintAs, isWriteColumn: true }
                       )
                     })}
                   }
@@ -646,7 +647,7 @@ export type Database = {
                                  is_nullable: true,
                                  is_optional: true,
                                },
-                               { types, schemas, tables, views, bigintAs }
+                               { types, schemas, tables, views, bigintAs, isWriteColumn: true }
                              )
                            })}
                          }
@@ -663,7 +664,7 @@ export type Database = {
                                  is_nullable: true,
                                  is_optional: true,
                                },
-                               { types, schemas, tables, views, bigintAs }
+                               { types, schemas, tables, views, bigintAs, isWriteColumn: true }
                              )
                            })}
                          }
@@ -878,6 +879,22 @@ export const Constants = {
   return output
 }
 
+// `bigintAs` is a pipe-delimited set of TypeScript representations for int8/numeric columns on
+// Insert/Update, for example "number|bigint". Only `number` and `bigint` are accepted: `bigint`
+// is the lossless write channel (postgrest-js serializes it to a JSON string), while `number`
+// keeps the ergonomic path for small values. `string` is deliberately excluded, since an
+// arbitrary non-numeric string would pass the type check and only fail at runtime in PostgREST.
+// Unknown tokens are ignored, and an empty result falls back to "number".
+const BIGINT_AS_REPRESENTATIONS = ['number', 'bigint']
+export const bigintAsToTsType = (bigintAs: string): string => {
+  const representations = bigintAs
+    .split('|')
+    .map((value) => value.trim())
+    .filter((value) => BIGINT_AS_REPRESENTATIONS.includes(value))
+  const unique = [...new Set(representations)]
+  return unique.length > 0 ? unique.join(' | ') : 'number'
+}
+
 // TODO: Make this more robust. Currently doesn't handle range types - returns them as unknown.
 export const pgTypeToTsType = (
   schema: PostgresSchema,
@@ -888,12 +905,14 @@ export const pgTypeToTsType = (
     tables,
     views,
     bigintAs = 'number',
+    isWriteColumn = false,
   }: {
     types: PostgresType[]
     schemas: PostgresSchema[]
     tables: PostgresTable[]
     views: PostgresView[]
-    bigintAs?: 'number' | 'string' | 'bigint'
+    bigintAs?: string
+    isWriteColumn?: boolean
   }
 ): string => {
   if (pgType === 'bool') {
@@ -901,13 +920,10 @@ export const pgTypeToTsType = (
   } else if (['int2', 'int4', 'float4', 'float8'].includes(pgType)) {
     return 'number'
   } else if (['int8', 'numeric'].includes(pgType)) {
-    if (bigintAs === 'string') {
-      return 'string'
-    }
-    if (bigintAs === 'bigint') {
-      return 'bigint'
-    }
-    return 'number'
+    // int8/numeric can exceed Number.MAX_SAFE_INTEGER. On reads they stay `number` to match the
+    // (lossy) JSON number PostgREST returns; cast to ::text for the exact value. On writes the
+    // column is widened to the `bigintAs` representations so callers can pass a lossless form.
+    return isWriteColumn ? bigintAsToTsType(bigintAs) : 'number'
   } else if (
     [
       'bytea',
@@ -939,6 +955,7 @@ export const pgTypeToTsType = (
       tables,
       views,
       bigintAs,
+      isWriteColumn,
     })})[]`
   } else {
     const enumTypes = types.filter((type) => type.name === pgType && type.enums.length > 0)

--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -31,9 +31,11 @@ export const apply = async ({
   types,
   detectOneToOneRelationships,
   postgrestVersion,
+  bigintAs = 'number',
 }: GeneratorMetadata & {
   detectOneToOneRelationships: boolean
   postgrestVersion?: string
+  bigintAs?: 'number' | 'string' | 'bigint'
 }): Promise<string> => {
   schemas.sort((a, b) => a.name.localeCompare(b.name))
   relationships.sort(
@@ -279,6 +281,7 @@ export const apply = async ({
             schemas,
             tables,
             views,
+            bigintAs,
           })
         }
         return { name, type: tsType }
@@ -314,6 +317,7 @@ export const apply = async ({
                       schemas,
                       tables,
                       views,
+                      bigintAs,
                     }
                   )
                 )
@@ -329,6 +333,7 @@ export const apply = async ({
         schemas,
         tables,
         views,
+        bigintAs,
       })
     }
 
@@ -426,6 +431,7 @@ export const apply = async ({
                   schemas,
                   tables,
                   views,
+                  bigintAs,
                 })
               }
               return { name, type: tsType, has_default }
@@ -445,6 +451,7 @@ export const apply = async ({
                   schemas,
                   tables,
                   views,
+                  bigintAs,
                 })
               }
               return { name, type: tsType, has_default }
@@ -462,6 +469,7 @@ export const apply = async ({
                 schemas,
                 tables,
                 views,
+                bigintAs,
               })
             }
             return { name, type: tsType, has_default }
@@ -503,6 +511,7 @@ export const apply = async ({
       schemas: PostgresSchema[]
       tables: PostgresTable[]
       views: PostgresView[]
+      bigintAs: 'number' | 'string' | 'bigint'
     }
   ) {
     return `${JSON.stringify(column.name)}${column.is_optional ? '?' : ''}: ${generateNullableUnionTsType(pgTypeToTsType(schema, column.format, context), column.is_nullable)}`
@@ -539,7 +548,7 @@ export type Database = {
                             is_nullable: column.is_nullable,
                             is_optional: false,
                           },
-                          { types, schemas, tables, views }
+                          { types, schemas, tables, views, bigintAs }
                         )
                       ),
                       ...schemaFunctions
@@ -565,7 +574,7 @@ export type Database = {
                             column.is_identity ||
                             column.default_value !== null,
                         },
-                        { types, schemas, tables, views }
+                        { types, schemas, tables, views, bigintAs }
                       )
                     })}
                   }
@@ -583,7 +592,7 @@ export type Database = {
                           is_nullable: column.is_nullable,
                           is_optional: true,
                         },
-                        { types, schemas, tables, views }
+                        { types, schemas, tables, views, bigintAs }
                       )
                     })}
                   }
@@ -611,7 +620,7 @@ export type Database = {
                             is_nullable: column.is_nullable,
                             is_optional: false,
                           },
-                          { types, schemas, tables, views }
+                          { types, schemas, tables, views, bigintAs }
                         )
                       ),
                       ...schemaFunctions
@@ -637,7 +646,7 @@ export type Database = {
                                  is_nullable: true,
                                  is_optional: true,
                                },
-                               { types, schemas, tables, views }
+                               { types, schemas, tables, views, bigintAs }
                              )
                            })}
                          }
@@ -654,7 +663,7 @@ export type Database = {
                                  is_nullable: true,
                                  is_optional: true,
                                },
-                               { types, schemas, tables, views }
+                               { types, schemas, tables, views, bigintAs }
                              )
                            })}
                          }
@@ -725,6 +734,7 @@ export type Database = {
                                 schemas,
                                 tables,
                                 views,
+                                bigintAs,
                               }),
                               true
                             )}`
@@ -877,16 +887,26 @@ export const pgTypeToTsType = (
     schemas,
     tables,
     views,
+    bigintAs = 'number',
   }: {
     types: PostgresType[]
     schemas: PostgresSchema[]
     tables: PostgresTable[]
     views: PostgresView[]
+    bigintAs?: 'number' | 'string' | 'bigint'
   }
 ): string => {
   if (pgType === 'bool') {
     return 'boolean'
-  } else if (['int2', 'int4', 'int8', 'float4', 'float8', 'numeric'].includes(pgType)) {
+  } else if (['int2', 'int4', 'float4', 'float8'].includes(pgType)) {
+    return 'number'
+  } else if (['int8', 'numeric'].includes(pgType)) {
+    if (bigintAs === 'string') {
+      return 'string'
+    }
+    if (bigintAs === 'bigint') {
+      return 'bigint'
+    }
     return 'number'
   } else if (
     [
@@ -918,6 +938,7 @@ export const pgTypeToTsType = (
       schemas,
       tables,
       views,
+      bigintAs,
     })})[]`
   } else {
     const enumTypes = types.filter((type) => type.name === pgType && type.enums.length > 0)

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -3649,35 +3649,38 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
 
 test('typegen: typescript w/ bigintAs defaults to number', async () => {
   const { body } = await app.inject({ method: 'GET', path: '/generators/typescript' })
-  // Back-compat: without the flag, int8 and numeric still generate as `number`.
-  expect(body).toContain('"user-id": number')
-  expect(body).toContain('days_since_event: number | null')
+  // Back-compat: without the flag, int8 and numeric generate as `number` on reads and writes.
+  expect(body).toContain('"user-id": number') // int8, Row
+  expect(body).toContain('"user-id"?: number') // int8, Insert/Update
+  expect(body).toContain('days_since_event: number | null') // numeric (computed), Row
 })
 
-test('typegen: typescript w/ bigintAs=string', async () => {
+test('typegen: typescript w/ bigint_as=number|bigint widens writes only', async () => {
   const { body } = await app.inject({
     method: 'GET',
     path: '/generators/typescript',
-    query: { bigint_as: 'string' },
+    query: { bigint_as: 'number|bigint' },
   })
-  // int8 and numeric can exceed Number.MAX_SAFE_INTEGER and are lossy as JS numbers,
-  // so they are emitted as `string` when bigint_as=string.
-  expect(body).toContain('"user-id": string') // int8 column
-  expect(body).toContain('days_since_event: string | null') // numeric (computed)
-  // int2/int4/float4/float8 fit safely in a JS number and are unaffected.
-  expect(body).toContain('details_length: number | null') // int4 (computed)
+  // int8/numeric can exceed Number.MAX_SAFE_INTEGER. Insert/Update widen to the union so callers
+  // can pass a lossless BigInt (postgrest-js serializes it to a JSON string).
+  expect(body).toContain('"user-id"?: number | bigint') // int8, Update
+  // Reads stay `number`: PostgREST returns int8 as a lossy JSON number; cast to ::text for the exact value.
+  expect(body).toContain('"user-id": number') // int8, Row unchanged
+  expect(body).toContain('days_since_event: number | null') // numeric (computed), Row unchanged
 })
 
-test('typegen: typescript w/ bigintAs=bigint', async () => {
+test('typegen: typescript w/ bigint_as=bigint widens writes only', async () => {
   const { body } = await app.inject({
     method: 'GET',
     path: '/generators/typescript',
     query: { bigint_as: 'bigint' },
   })
-  expect(body).toContain('"user-id": bigint') // int8 column
-  expect(body).toContain('days_since_event: bigint | null') // numeric (computed)
-  // int2/int4/float4/float8 remain `number`.
-  expect(body).toContain('details_length: number | null') // int4 (computed)
+  // `bigint` is the lossless write channel: postgrest-js serializes a BigInt to a JSON string,
+  // so values past Number.MAX_SAFE_INTEGER go in intact. It still only widens writes.
+  expect(body).toContain('"user-id"?: bigint') // int8, Update
+  // Reads stay `number`: PostgREST returns int8 as a lossy JSON number; cast to ::text for the exact value.
+  expect(body).toContain('"user-id": number') // int8, Row unchanged
+  expect(body).toContain('days_since_event: number | null') // numeric (computed), Row unchanged
 })
 
 test('typegen: typescript w/ postgrestVersion', async () => {

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -3647,6 +3647,39 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
   )
 })
 
+test('typegen: typescript w/ bigintAs defaults to number', async () => {
+  const { body } = await app.inject({ method: 'GET', path: '/generators/typescript' })
+  // Back-compat: without the flag, int8 and numeric still generate as `number`.
+  expect(body).toContain('"user-id": number')
+  expect(body).toContain('days_since_event: number | null')
+})
+
+test('typegen: typescript w/ bigintAs=string', async () => {
+  const { body } = await app.inject({
+    method: 'GET',
+    path: '/generators/typescript',
+    query: { bigint_as: 'string' },
+  })
+  // int8 and numeric can exceed Number.MAX_SAFE_INTEGER and are lossy as JS numbers,
+  // so they are emitted as `string` when bigint_as=string.
+  expect(body).toContain('"user-id": string') // int8 column
+  expect(body).toContain('days_since_event: string | null') // numeric (computed)
+  // int2/int4/float4/float8 fit safely in a JS number and are unaffected.
+  expect(body).toContain('details_length: number | null') // int4 (computed)
+})
+
+test('typegen: typescript w/ bigintAs=bigint', async () => {
+  const { body } = await app.inject({
+    method: 'GET',
+    path: '/generators/typescript',
+    query: { bigint_as: 'bigint' },
+  })
+  expect(body).toContain('"user-id": bigint') // int8 column
+  expect(body).toContain('days_since_event: bigint | null') // numeric (computed)
+  // int2/int4/float4/float8 remain `number`.
+  expect(body).toContain('details_length: number | null') // int4 (computed)
+})
+
 test('typegen: typescript w/ postgrestVersion', async () => {
   const { body } = await app.inject({
     method: 'GET',


### PR DESCRIPTION
Addresses #1078.

## Problem

`int8` and `numeric` are generated as TypeScript `number`, but values past `Number.MAX_SAFE_INTEGER` (2^53) are lossy once round-tripped through JSON. Consumers using snowflake/Instagram-style sharded IDs or `xxhash64` ETL output hit this in production: a row fetched by id gets a corrupted id back, and `/items/<id>` 404s.

## Approach

Adds an opt-in `bigint_as` option for the TypeScript generator that widens the **write** types for `int8`/`numeric` columns. It defaults to `number`, so existing consumers are unaffected.

The key change from the first revision: the option is applied per direction, not as a single scalar.

- **Row (read) stays `number`, always.** PostgREST returns an un-cast `int8` as a JSON number, so precision is already gone by the time `JSON.parse` runs. Typing the Row as anything else would misrepresent what actually comes over the wire. Consumers who need the exact value cast to `::text` and get a `string` back, and the select-query parser already infers `string` for the casted column.
- **Insert/Update (write) widen to the `bigint_as` union.** This is the lossless input channel: a JS `BigInt` is serialized by postgrest-js to a JSON string, so values past 2^53 go in intact. Widening the input type is pure back-compat (it only accepts more).

`bigint_as` is a pipe-delimited set passed as a single string, so the union is spelled inline, for example `bigint_as=number|bigint`. Accepted tokens are `number` and `bigint`; the recommended value is `number|bigint` (`bigint` for the lossless path, `number` for the ergonomic small-value case). Unknown tokens are ignored and an empty result falls back to `number`.

`string` is deliberately not accepted: an arbitrary non-numeric string would pass the type check and only fail at runtime in PostgREST. The documented pattern for the read-then-write case is to wrap the cast read value, `update({ ... }).eq('id', BigInt(entity.id))`.

Surfaced two ways, matching the existing generator-option conventions:
- Env var `PG_META_GENERATE_TYPES_BIGINT_AS` (standalone generation path), alongside `PG_META_GENERATE_TYPES_INCLUDED_SCHEMAS`, `_DEFAULT_SCHEMA`, etc.
- Query param `?bigint_as=` on `GET /generators/typescript`, alongside `detect_one_to_one_relationships` and `postgrest_version`.

The mapping is scoped exactly as mandarini pointed out on the issue: only `int8` and `numeric` are split out of the `number` branch. `int2`, `int4`, `float4`, and `float8` all fit safely in a JS `number` and are left untouched.

## Runtime evidence

The read/write model above is demonstrated end to end in supabase/supabase-js#2461 (postgrest-js), which seeds `9223372036854775807` (2^63 - 1) in Postgres and exercises the API:

- un-cast read returns the lossy JS number `9223372036854776000`,
- `::text` read returns the exact string `"9223372036854775807"`,
- writing a value above 2^53 as a string (or a `BigInt`) round-trips losslessly,
- writing it as a JS number is lossy before it ever leaves the client.

So the runtime already handles these values on both paths, and `bigint_as` makes the generated write types reflect the lossless one.

## Scope

TypeScript template only, and within it the table/view `Insert`/`Update` types. Row types and function returns/arguments are left as `number`. The sibling templates (`go.ts`, `python.ts`, `swift.ts`) that mandarini flagged as parallel work are intentionally left for a follow-up once the option shape is settled, to keep this PR reviewable.

## Tests

Three focused cases in `test/server/typegen.ts`, using the existing fixtures (`todos."user-id"` is `int8`, the `days_since_event` computed field is `numeric`):

- `bigint_as` defaults to `number`: back-compat, `"user-id": number` (Row) and `"user-id"?: number` (Insert/Update).
- `bigint_as=number|bigint`: `"user-id"?: number | bigint` on Insert/Update, while the Row stays `"user-id": number` and `days_since_event: number | null`.
- `bigint_as=bigint`: `"user-id"?: bigint` on Insert/Update, Row unchanged.

Each case asserts the read/write asymmetry directly (the Row assertions are the regression guard that reads are never widened). Used `toContain` (as the schema-filter tests already do) rather than full snapshots, to keep the surgical behavior of the option legible. Happy to convert to inline snapshots if you would prefer consistency with the other typegen cases.

## Docs

No README change: the README documents only the DB connection vars, none of the existing generator options (`INCLUDED_SCHEMAS`, `DEFAULT_SCHEMA`, `SWIFT_ACCESS_CONTROL`) live there, and the route uses inline types rather than a Fastify JSON schema, so there is no OpenAPI entry to update. Glad to add docs wherever you would want them.

Thanks @mandarini for transferring the issue with the `typescript.ts:889` pointer and the wire-format context, and @avallete for working through the read/write direction on #2461. That is what settled this into a contained, back-compatible change. Happy to adjust direction on any of the above.
