### PR TITLE
fix(typescript): generate non-nullable json columns as NonNullable<Json>

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -483,6 +483,11 @@ export const apply = async ({
     : ''
 
   function generateNullableUnionTsType(tsType: string, isNullable: boolean) {
+    // The Json type already includes `null`, so a NOT NULL json/jsonb column has to be
+    // narrowed with NonNullable to reflect the database constraint. See supabase/postgres-meta#1055.
+    if (tsType === 'Json' && !isNullable) {
+      return `NonNullable<${tsType}>`
+    }
     // Only add the null union if the type is not unknown as unknown already includes null
     if (tsType === 'unknown' || tsType === 'any' || !isNullable) {
       return tsType

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -6964,3 +6964,46 @@ test('typegen: python w/ excluded/included schemas', async () => {
     })
   }
 })
+
+test('typegen: typescript w/ NOT NULL json column narrows Json to NonNullable<Json>', async () => {
+  // The generated Json type includes `null`, so a NOT NULL json/jsonb column has to be
+  // narrowed with NonNullable to honor the database constraint. A nullable json column is
+  // left as-is because Json already covers null. See supabase/postgres-meta#1055.
+  await app.inject({
+    method: 'POST',
+    path: '/query',
+    payload: {
+      query: `
+        CREATE SCHEMA IF NOT EXISTS json_nullability_test;
+        CREATE TABLE IF NOT EXISTS json_nullability_test.documents (
+          id serial PRIMARY KEY,
+          required_metadata jsonb NOT NULL,
+          optional_metadata jsonb
+        );
+      `,
+    },
+  })
+
+  try {
+    const { body } = await app.inject({
+      method: 'GET',
+      path: '/generators/typescript',
+      query: { included_schemas: 'json_nullability_test' },
+    })
+    // NOT NULL jsonb narrows to NonNullable<Json> (Row and Insert).
+    expect(body).toContain('required_metadata: NonNullable<Json>')
+    expect(body).not.toContain('required_metadata: Json | null')
+    // Nullable jsonb is unchanged: Json already includes null.
+    expect(body).toContain('optional_metadata: Json | null')
+  } finally {
+    await app.inject({
+      method: 'POST',
+      path: '/query',
+      payload: {
+        query: `
+          DROP SCHEMA IF EXISTS json_nullability_test CASCADE;
+        `,
+      },
+    })
+  }
+})


### PR DESCRIPTION
## Problem

A `NOT NULL` `json`/`jsonb` column generates the TypeScript type `Json`, but the generated `Json` type is itself nullable:

```ts
export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
```

So the column type structurally permits `null` even though Postgres forbids it. Studio reports the column as non-nullable, but the generated types disagree.

Closes #1055.

## Fix

`generateNullableUnionTsType` already special-cases `unknown`/`any` (which include `null`) by not appending `| null`. This applies the same reasoning to `Json`: a non-nullable `json`/`jsonb` column is narrowed to `NonNullable<Json>` so the type reflects the database constraint.

```ts
if (tsType === 'Json' && !isNullable) {
  return `NonNullable<${tsType}>`
}
```

## Scope

- Only non-nullable `json`/`jsonb` columns change (`Json` becomes `NonNullable<Json>`). Nullable `json` columns are untouched, since `Json` already covers `null`.
- The change sits in the single nullability chokepoint, so it covers Row, Insert, and Update consistently. Function return types and composite-type attributes call this helper with `isNullable: true`, so they are unaffected. Array types (`(Json)[]`) are unaffected.

## Tests

Added a regression test that spins up a throwaway schema with a `NOT NULL jsonb` column and a nullable `jsonb` column, generates types scoped to it, and asserts the non-nullable column is `NonNullable<Json>` while the nullable one stays `Json | null`. It follows the inline-schema pattern from the existing included/excluded-schemas test, so it adds no fixture churn to the shared snapshots.

## Note on the type-generation extraction

I see #1084 and supabase/pg-toolbelt#302 are moving these templates into `@supabase/postgrest-typegen`. This patch targets `typescript.ts` here; happy to port the same one-line guard to the extracted package instead if that is the better home. @avallete
