### PR TITLE
fix(typegen): map vector type to number[] in TypeScript type generation

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -901,11 +901,12 @@ export const pgTypeToTsType = (
       'timestamp',
       'timestamptz',
       'uuid',
-      'vector',
       'interval',
     ].includes(pgType)
   ) {
     return 'string'
+  } else if (pgType === 'vector') {
+    return 'number[]'
   } else if (['json', 'jsonb'].includes(pgType)) {
     return 'Json'
   } else if (pgType === 'void') {

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -55,4 +55,26 @@ describe('server/routes/types', () => {
 
     expect(result).toBe('string')
   })
+
+  test('vector column maps to number[]', () => {
+    const result = pgTypeToTsType({ name: 'public' } as any, 'vector', {
+      types: [],
+      schemas: [],
+      tables: [],
+      views: [],
+    })
+
+    expect(result).toBe('number[]')
+  })
+
+  test('vector array column (_vector) maps to (number[])[]', () => {
+    const result = pgTypeToTsType({ name: 'public' } as any, '_vector', {
+      types: [],
+      schemas: [],
+      tables: [],
+      views: [],
+    })
+
+    expect(result).toBe('(number[])[]')
+  })
 })


### PR DESCRIPTION
## Problem

When using `supabase gen types typescript` with RPC functions that have vector parameters, the generated types are `string`. However, the actual Supabase client requires `number[]` to work correctly.

For table columns, `JSON.stringify()` serves as a workaround, but for RPC functions it does not work and causes queries to fail or return zero results because they need to be passed as raw arrays.

## Fix

Mapped the `vector` type in `pgTypeToTsType` to `number[]`. This resolves the `vector` parameter type to `number[]`, and by recursion correctly maps the array `_vector` to `(number[])[]`.

## Tests

Added two unit tests in `test/types.test.ts`:
- `vector column maps to number[]`
- `vector array column (_vector) maps to (number[])[]`

Ran the tests locally using a custom unit test runner (since the full vitest suite requires Docker / Sentry setup), and verified that:
- `vector` correctly maps to `number[]`
- `_vector` correctly maps to `(number[])[]`

Fixes #1029