### PR TITLE
fix: improve literal escapes

### DIFF
--- a/src/lib/PostgresMetaRoles.ts
+++ b/src/lib/PostgresMetaRoles.ts
@@ -7,6 +7,18 @@ import {
   PostgresRoleUpdate,
 } from './types.js'
 import { filterByValue } from './helpers.js'
+
+// GUC_LIST_INPUT parameters (e.g. search_path) expect a comma-separated list of
+// individually-quoted values, not the whole comma-containing string as one literal -
+// escape each list item separately so multi-value configs round-trip correctly.
+const literalConfigValue = (value: string | null): string =>
+  value === null
+    ? literal(value)
+    : value
+        .split(',')
+        .map((part) => literal(part.trim()))
+        .join(',')
+
 export function changeRoleConfig2Object(config: string[]) {
   if (!config) {
     return null
@@ -122,7 +134,7 @@ export default class PostgresMetaRoles {
           if (!k || !v) {
             return ''
           }
-          return `ALTER ROLE ${ident(name)} SET ${ident(k)} = ${literal(v)};`
+          return `ALTER ROLE ${ident(name)} SET ${ident(k)} = ${literalConfigValue(v)};`
         })
         .join('\n')
     }
@@ -220,7 +232,7 @@ COMMIT;`
         switch (op) {
           case 'add':
           case 'replace':
-            return `ALTER ROLE ${ident(old!.name)} SET ${ident(k)} = ${literal(v)};`
+            return `ALTER ROLE ${ident(old!.name)} SET ${ident(k)} = ${literalConfigValue(v)};`
           case 'remove':
             return `ALTER ROLE ${ident(old!.name)} RESET ${ident(k)};`
           default:

--- a/src/lib/PostgresMetaRoles.ts
+++ b/src/lib/PostgresMetaRoles.ts
@@ -110,9 +110,10 @@ export default class PostgresMetaRoles {
     const connectionLimitClause = `CONNECTION LIMIT ${connection_limit}`
     const passwordClause = password === undefined ? '' : `PASSWORD ${literal(password)}`
     const validUntilClause = valid_until === undefined ? '' : `VALID UNTIL ${literal(valid_until)}`
-    const memberOfClause = member_of === undefined ? '' : `IN ROLE ${member_of.join(',')}`
-    const membersClause = members === undefined ? '' : `ROLE ${members.join(',')}`
-    const adminsClause = admins === undefined ? '' : `ADMIN ${admins.join(',')}`
+    const memberOfClause =
+      member_of === undefined ? '' : `IN ROLE ${member_of.map((r) => ident(r)).join(',')}`
+    const membersClause = members === undefined ? '' : `ROLE ${members.map((r) => ident(r)).join(',')}`
+    const adminsClause = admins === undefined ? '' : `ADMIN ${admins.map((r) => ident(r)).join(',')}`
     let configClause = ''
     if (config !== undefined) {
       configClause = Object.keys(config)
@@ -121,7 +122,7 @@ export default class PostgresMetaRoles {
           if (!k || !v) {
             return ''
           }
-          return `ALTER ROLE ${name} SET ${k} = ${v};`
+          return `ALTER ROLE ${ident(name)} SET ${ident(k)} = ${literal(v)};`
         })
         .join('\n')
     }

--- a/src/lib/PostgresMetaRoles.ts
+++ b/src/lib/PostgresMetaRoles.ts
@@ -124,8 +124,10 @@ export default class PostgresMetaRoles {
     const validUntilClause = valid_until === undefined ? '' : `VALID UNTIL ${literal(valid_until)}`
     const memberOfClause =
       member_of === undefined ? '' : `IN ROLE ${member_of.map((r) => ident(r)).join(',')}`
-    const membersClause = members === undefined ? '' : `ROLE ${members.map((r) => ident(r)).join(',')}`
-    const adminsClause = admins === undefined ? '' : `ADMIN ${admins.map((r) => ident(r)).join(',')}`
+    const membersClause =
+      members === undefined ? '' : `ROLE ${members.map((r) => ident(r)).join(',')}`
+    const adminsClause =
+      admins === undefined ? '' : `ADMIN ${admins.map((r) => ident(r)).join(',')}`
     let configClause = ''
     if (config !== undefined) {
       configClause = Object.keys(config)

--- a/src/lib/PostgresMetaTablePrivileges.ts
+++ b/src/lib/PostgresMetaTablePrivileges.ts
@@ -121,7 +121,9 @@ begin
 ${revokes
   .map(
     (revoke) =>
-      `execute format('revoke ${revoke.privilege_type} on table %s from ${revoke.grantee}', ${revoke.relation_id}::regclass);`
+      `execute format('revoke ${revoke.privilege_type} on table %s from ${
+        revoke.grantee.toLowerCase() === 'public' ? 'public' : ident(revoke.grantee)
+      }', ${revoke.relation_id}::regclass);`
   )
   .join('\n')}
 end $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

GUC values aren't correctly literal escaped (for `SET search_path = ` for example)

## What is the new behavior?

GUC values are correctly escaped. 

## Additional context

Covers some additional statements that weren't escaped before
