### PR TITLE
fix: null body crash, null config guard, and roles querystring schema mismatch

### DIFF
--- a/src/lib/PostgresMetaRoles.ts
+++ b/src/lib/PostgresMetaRoles.ts
@@ -223,7 +223,7 @@ COMMIT;`
     const passwordClause = password === undefined ? '' : `PASSWORD ${literal(password)}`
     const validUntilClause = valid_until === undefined ? '' : `VALID UNTIL ${literal(valid_until)}`
     let configClause = ''
-    if (config !== undefined) {
+    if (config != null) {
       const configSql = config.map((c) => {
         const { op, path, value } = c
         const k = path

--- a/src/server/routes/query.ts
+++ b/src/server/routes/query.ts
@@ -8,7 +8,7 @@ import {
 } from '../utils.js'
 
 const errorOnEmptyQuery = (request: FastifyRequest) => {
-  if (!(request.body as any).query) {
+  if (!request.body || !(request.body as any).query) {
     throw new Error('query not found')
   }
 }
@@ -74,7 +74,7 @@ export default async (fastify: FastifyInstance) => {
     Headers: { pg: string; 'x-pg-application-name'?: string }
     Body: { ast: object }
   }>('/deparse', async (request, reply) => {
-    const { data, error } = await Parser.Deparse(request.body.ast)
+    const { data, error } = await Parser.Deparse(request.body?.ast ?? {})
 
     if (error) {
       request.log.error({ error, request: extractRequestForLogging(request) })

--- a/src/server/routes/roles.ts
+++ b/src/server/routes/roles.ts
@@ -27,7 +27,7 @@ export default async (fastify: FastifyInstance) => {
           'x-pg-application-name': Type.Optional(Type.String()),
         }),
         querystring: Type.Object({
-          include_system_schemas: Type.Optional(Type.String()),
+          include_default_roles: Type.Optional(Type.String()),
           limit: Type.Optional(Type.String()),
           offset: Type.Optional(Type.String()),
         }),


### PR DESCRIPTION
## Summary

Four fixes in postgres-meta.

| # | File | Bug |
|---|---|---|
| 1 | `routes/query.ts` | `errorOnEmptyQuery` crashed on null body — `null.query` TypeError instead of intended error message |
| 2 | `routes/query.ts` | `/deparse` route had no null guard on `request.body.ast` |
| 3 | `PostgresMetaRoles.ts` | `config !== undefined` allowed null through → `null.map()` TypeError |
| 4 | `routes/roles.ts` | Querystring schema declared `include_system_schemas` but handler read `include_default_roles` — validated field never used |