### PR TITLE
fix: support Python 3.9 type generation

### DIFF
--- a/src/server/templates/python.ts
+++ b/src/server/templates/python.ts
@@ -40,11 +40,10 @@ from typing import (
     Any,
     List,
     Literal,
-    NotRequired,
     Optional,
-    TypeAlias,
     TypedDict,
 )
+from typing_extensions import NotRequired, TypeAlias
 
 from pydantic import BaseModel, Field, Json
 

--- a/test/server/templates/python.test.ts
+++ b/test/server/templates/python.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest'
+
+import type { GeneratorMetadata } from '../../../src/lib/generators'
+import { apply } from '../../../src/server/templates/python'
+
+const emptyMetadata: GeneratorMetadata = {
+  schemas: [],
+  tables: [],
+  foreignTables: [],
+  views: [],
+  materializedViews: [],
+  columns: [],
+  relationships: [],
+  functions: [],
+  types: [],
+}
+
+test('imports compatibility typing helpers from typing_extensions', () => {
+  const result = apply(emptyMetadata)
+  const typingImport = result.match(/from typing import \(([\s\S]*?)\)/)?.[1]
+
+  expect(typingImport).not.toContain('NotRequired')
+  expect(typingImport).not.toContain('TypeAlias')
+  expect(result).toContain('from typing_extensions import NotRequired, TypeAlias')
+})

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -6624,6 +6624,7 @@ test('typegen: python', async () => {
     path: '/generators/python',
     query: { access_control: 'public' },
   })
+  expect(body).toContain('from typing_extensions import NotRequired, TypeAlias')
   expect(body).toMatchInlineSnapshot(`
     "from __future__ import annotations
 
@@ -6634,11 +6635,10 @@ test('typegen: python', async () => {
         Any,
         List,
         Literal,
-        NotRequired,
         Optional,
-        TypeAlias,
         TypedDict,
     )
+    from typing_extensions import NotRequired, TypeAlias
 
     from pydantic import BaseModel, Field, Json
 


### PR DESCRIPTION
## Summary
- import `NotRequired` and `TypeAlias` from `typing_extensions`
- support generated Python types on Python 3.9 and 3.10
- add a focused regression test and update the integration snapshot

## Test plan
- `npm run check`
- Prettier check passed
- focused Python generator unit test passed
- Python generator integration test passed
- imports validated with Pydantic on Python 3.9, 3.10, and 3.11

Fixes #1088