### PR TITLE
fix(typegen): only collapse ROWS 1 return types when SetofOptions is emitted

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -262,7 +262,12 @@ export const apply = async ({
       }
     }
 
-    return `${returnType}${fn.is_set_returning_function && returnsMultipleRows ? '[]' : ''}
+    // A ROWS 1 estimate may only collapse the array type when SetofOptions is also emitted
+    // (returnTableName resolved): postgrest-js relies on isOneToOne to restore the array shape
+    // for direct RPC calls. Without that metadata PostgREST still returns an array, so the
+    // collapse would make the type diverge from the actual response.
+    const collapsibleSingleRow = !returnsMultipleRows && returnTableName !== null
+    return `${returnType}${fn.is_set_returning_function && !collapsibleSingleRow ? '[]' : ''}
                           ${setofOptionsInfo ? `${setofOptionsInfo}` : ''}`
   }
 

--- a/test/db/00-init.sql
+++ b/test/db/00-init.sql
@@ -501,3 +501,24 @@ STABLE
 AS $$
   SELECT interval_test_row.duration_required * 2;
 $$;
+
+-- Set-returning function with an ad-hoc TABLE return type and a ROWS 1 estimate.
+-- ROWS 1 is only a planner estimate: PostgREST still returns an array, and with no
+-- named relation there is no SetofOptions metadata to restore the array shape, so
+-- the generated return type must keep the array.
+CREATE OR REPLACE FUNCTION public.get_todos_summary_rows_one()
+RETURNS TABLE (id int, name text)
+LANGUAGE SQL STABLE
+ROWS 1
+AS $$
+  SELECT 1 AS id, 'test' AS name;
+$$;
+
+-- Set-returning scalar function with a ROWS 1 estimate: array type must be kept here too.
+CREATE OR REPLACE FUNCTION public.get_todo_ids_rows_one()
+RETURNS SETOF bigint
+LANGUAGE SQL STABLE
+ROWS 1
+AS $$
+  SELECT id FROM public.todos LIMIT 1;
+$$;

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -753,6 +753,7 @@ test('typegen: typescript', async () => {
                   isSetofReturn: true
                 }
               }
+          get_todo_ids_rows_one: { Args: never; Returns: number[] }
           get_todos_by_matview: {
             Args: { "": unknown }
             Returns: {
@@ -841,6 +842,13 @@ test('typegen: typescript', async () => {
                   isSetofReturn: true
                 }
               }
+          get_todos_summary_rows_one: {
+            Args: never
+            Returns: {
+              id: number
+              name: string
+            }[]
+          }
           get_user_audit_setof_single_row: {
             Args: { user_row: Database["public"]["Tables"]["users"]["Row"] }
             Returns: {
@@ -1978,6 +1986,7 @@ test('typegen w/ one-to-one relationships', async () => {
                   isSetofReturn: true
                 }
               }
+          get_todo_ids_rows_one: { Args: never; Returns: number[] }
           get_todos_by_matview: {
             Args: { "": unknown }
             Returns: {
@@ -2066,6 +2075,13 @@ test('typegen w/ one-to-one relationships', async () => {
                   isSetofReturn: true
                 }
               }
+          get_todos_summary_rows_one: {
+            Args: never
+            Returns: {
+              id: number
+              name: string
+            }[]
+          }
           get_user_audit_setof_single_row: {
             Args: { user_row: Database["public"]["Tables"]["users"]["Row"] }
             Returns: {
@@ -3203,6 +3219,7 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
                   isSetofReturn: true
                 }
               }
+          get_todo_ids_rows_one: { Args: never; Returns: number[] }
           get_todos_by_matview: {
             Args: { "": unknown }
             Returns: {
@@ -3291,6 +3308,13 @@ test('typegen: typescript w/ one-to-one relationships', async () => {
                   isSetofReturn: true
                 }
               }
+          get_todos_summary_rows_one: {
+            Args: never
+            Returns: {
+              id: number
+              name: string
+            }[]
+          }
           get_user_audit_setof_single_row: {
             Args: { user_row: Database["public"]["Tables"]["users"]["Row"] }
             Returns: {
@@ -4433,6 +4457,7 @@ test('typegen: typescript w/ postgrestVersion', async () => {
                   isSetofReturn: true
                 }
               }
+          get_todo_ids_rows_one: { Args: never; Returns: number[] }
           get_todos_by_matview: {
             Args: { "": unknown }
             Returns: {
@@ -4521,6 +4546,13 @@ test('typegen: typescript w/ postgrestVersion', async () => {
                   isSetofReturn: true
                 }
               }
+          get_todos_summary_rows_one: {
+            Args: never
+            Returns: {
+              id: number
+              name: string
+            }[]
+          }
           get_user_audit_setof_single_row: {
             Args: { user_row: Database["public"]["Tables"]["users"]["Row"] }
             Returns: {


### PR DESCRIPTION
Fixes supabase/supabase#46525.

The TypeScript typegen drops the `[]` from the return type of every set-returning function declared with `ROWS 1`, but the compensating `SetofOptions` metadata is only emitted when the function returns a named table, view, or composite type. For ad-hoc `RETURNS TABLE (...)` and scalar `SETOF` functions this produced a single-object type while PostgREST still returns an array at runtime, and there is no metadata for postgrest-js to correct it. The collapse is now gated on the same condition as the `SetofOptions` emission, so those functions keep the array type, while named-relation functions (where postgrest-js restores the array for direct RPC calls via `isOneToOne`) are unchanged.

Note for consumers: regenerating types flips `Returns` from object to array for affected functions. The resulting type errors point at real runtime mismatches, since PostgREST has always returned an array for these calls.