### PR TITLE
fix(ci): Pin npm to v11 for Node 20 compatibility in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,8 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Update npm
-        run: npm install -g npm@latest
+        # npm >= 11.5.1 is needed for trusted publishing; npm 12 dropped Node 20 support
+        run: npm install -g npm@11
 
       - run: |
           npm clean-install


### PR DESCRIPTION
## Summary
Updates the npm version constraint in the release workflow to pin to npm v11 instead of always installing the latest version. This ensures compatibility with Node 20, which is the minimum supported version for this project.

## Changes
- Changed `npm install -g npm@latest` to `npm install -g npm@11` in the release workflow
- Added clarifying comment explaining that npm >= 11.5.1 is required for trusted publishing and npm 12 dropped Node 20 support

## Details
The release workflow previously installed the latest npm version globally, which could cause issues since npm 12 dropped support for Node 20. By pinning to npm v11, we ensure the workflow uses a version that:
- Supports Node 20 (the project's minimum supported version per CLAUDE.md)
- Includes npm >= 11.5.1 which is needed for trusted publishing
- Remains stable and compatible with the project's CI/CD pipeline

https://claude.ai/code/session_018Qan7ZWehTJKYRDSRSEDqk