### PR TITLE
fix(ci): pass GITHUB_TOKEN to swagger-ui-action in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           output: docs
           spec-file: openapi.json
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0


### PR DESCRIPTION
The Docs workflow has been failing at the **Generate Swagger UI** step on every master push (e.g. [this run](https://github.com/supabase/postgres-meta/actions/runs/31091367020/job/92582908336)) with:

```
Error: [@octokit/auth-action] `GITHUB_TOKEN` variable is not set. It must be set on either `env:` or `with:`.
```

`Legion2/swagger-ui-action` uses the token to query/download the swagger-ui release via the GitHub API and declares `GITHUB_TOKEN` as an input ([action.yml](https://github.com/Legion2/swagger-ui-action/blob/eff65dc3f193f0a749872be82f74baa35be0797d/action.yml#L24-L26)) — this workflow never passed it. The subsequent Publish step already receives `secrets.GITHUB_TOKEN`, so this just brings the swagger step in line.

Unrelated to the release pipeline (#1097) — docs publishing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)