### PR TITLE
fix: Avoid quadratic relationship lookup in typescript generator

### DIFF
--- a/src/server/templates/typescript.ts
+++ b/src/server/templates/typescript.ts
@@ -96,19 +96,27 @@ export const apply = async ({
     }
   }
 
-  function getRelationships(
-    object: { schema: string; name: string },
-    relationships: GeneratorMetadata['relationships']
-  ): Pick<
+  const relationshipsByRelation = new Map<string, GeneratorMetadata['relationships']>()
+  for (const relationship of relationships) {
+    const key = `${relationship.schema}.${relationship.relation}`
+    let bucket = relationshipsByRelation.get(key)
+    if (!bucket) {
+      bucket = []
+      relationshipsByRelation.set(key, bucket)
+    }
+    bucket.push(relationship)
+  }
+
+  function getRelationships(object: {
+    schema: string
+    name: string
+  }): Pick<
     GeneratorMetadata['relationships'][number],
     'foreign_key_name' | 'columns' | 'is_one_to_one' | 'referenced_relation' | 'referenced_columns'
   >[] {
-    return relationships.filter(
-      (relationship) =>
-        relationship.schema === object.schema &&
-        relationship.referenced_schema === object.schema &&
-        relationship.relation === object.name
-    )
+    const candidates = relationshipsByRelation.get(`${object.schema}.${object.name}`)
+    if (!candidates) return []
+    return candidates.filter((relationship) => relationship.referenced_schema === object.schema)
   }
 
   function generateRelationshiptTsDefinition(relationship: TsRelationship): string {
@@ -124,7 +132,7 @@ export const apply = async ({
     if (table.schema in introspectionBySchema) {
       introspectionBySchema[table.schema].tables.push({
         table,
-        relationships: getRelationships(table, relationships),
+        relationships: getRelationships(table),
       })
     }
   }
@@ -132,7 +140,7 @@ export const apply = async ({
     if (table.schema in introspectionBySchema) {
       introspectionBySchema[table.schema].tables.push({
         table,
-        relationships: getRelationships(table, relationships),
+        relationships: getRelationships(table),
       })
     }
   }
@@ -140,7 +148,7 @@ export const apply = async ({
     if (view.schema in introspectionBySchema) {
       introspectionBySchema[view.schema].views.push({
         view,
-        relationships: getRelationships(view, relationships),
+        relationships: getRelationships(view),
       })
     }
   }
@@ -151,7 +159,7 @@ export const apply = async ({
           ...materializedView,
           is_updatable: false,
         },
-        relationships: getRelationships(materializedView, relationships),
+        relationships: getRelationships(materializedView),
       })
     }
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Improves the performance of `/generators/typescript` endpoint

## What is the current behavior?

`getRelationships` in the TypeScript type generator (`src/server/templates/typescript.ts`) is called once per table/view, and each call does a full linear scan (`.filter()`) over all relationships in the schema to find the ones belonging to that table. This makes the overall type-generation pass O(tables × relationships) — for schemas with many tables and foreign keys, this scales quadratically and can turn into a long-running, CPU-bound, synchronous operation for large schemas.

Because this work runs synchronously on the Node.js event loop, a single request against a large enough schema could block the process entirely for its duration — delaying or timing out every other in-flight request until it finished. In effect, one expensive request was enough to make the whole service become unresponsive.

## What is the new behavior?

`getRelationships` now groups all relationships into a `Map` keyed by `schema.relation` in a single upfront pass, and each table/view lookup becomes an O(1) map lookup instead of a full scan. This reduces the overall complexity from O(tables × relationships) to O(tables + relationships), with no change to the generated output.

## Additional context

No functional/output changes — the generated TypeScript types are identical; this is purely an algorithmic complexity fix aimed at reducing CPU usage and latency for large schemas, and preventing a single expensive request from stalling the rest of the service.