### PR TITLE
fix: Add configurable shutdown grace period for graceful server termination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ PG_CONN_TIMEOUT_SECS=15                 # Connection timeout (default: 15)
 PG_QUERY_TIMEOUT_SECS=55                # Query timeout (default: 55)
 PG_META_MAX_RESULT_SIZE_MB=20           # Max query result size in MB (default: 2048MB)
 PG_META_MAX_BODY_LIMIT_MB=3             # Max request body size in MB (default: 3MB)
+PG_META_SHUTDOWN_GRACE_PERIOD_SECS=10   # Shutdown wait on in-flight work before force-exit (default: 10)
 ```
 
 Type generation formatting (opt-in):

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -104,3 +104,10 @@ export const FORMAT_TIMEOUT_MS = Number(process.env.PG_META_FORMAT_TIMEOUT_SECS 
 // (and tests can finish) without an explicit teardown.
 export const FORMAT_IDLE_TIMEOUT_MS =
   Number(process.env.PG_META_FORMAT_IDLE_TIMEOUT_SECS || 30) * 1000
+
+// How long a shutdown may wait on in-flight work before the process
+// force-exits. Note the container runtime SIGKILLs at its own stop grace
+// period (10s by default in Docker, same as this default), so set this lower
+// than that for the force-exit to actually run.
+export const SHUTDOWN_GRACE_PERIOD_MS =
+  Number(process.env.PG_META_SHUTDOWN_GRACE_PERIOD_SECS || 10) * 1000

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -14,6 +14,7 @@ import {
   PG_META_HOST,
   PG_META_PORT,
   POSTGREST_VERSION,
+  SHUTDOWN_GRACE_PERIOD_MS,
 } from './constants.js'
 import { destroyFormatPool } from './format-pool.js'
 import { apply as applyTypescriptTemplate } from './templates/typescript.js'
@@ -160,10 +161,7 @@ if (EXPORT_DOCS) {
 } else if (GENERATE_TYPES) {
   console.log(await getTypeOutput())
 } else {
-  // The delay must stay well under container runtimes' stop grace period
-  // (10s by default in Docker), or the process gets SIGKILLed before it can
-  // exit cleanly.
-  closeWithGrace({ delay: 1500 }, async ({ err, signal, manual }) => {
+  closeWithGrace({ delay: SHUTDOWN_GRACE_PERIOD_MS }, async ({ err, signal, manual }) => {
     if (err) {
       app.log.error({ err }, 'server closing with error')
     } else {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -170,7 +170,9 @@ if (EXPORT_DOCS) {
     await app.close().catch((err) => app.log.error({ err }, 'Failed to close app'))
     await adminApp.close().catch((err) => app.log.error({ err }, 'Failed to close adminApp'))
     // worker threads keep the event loop alive, so the process would not exit
-    await destroyFormatPool().catch((err) => app.log.error({ err }, 'Failed to destroy format pool'))
+    await destroyFormatPool().catch((err) =>
+      app.log.error({ err }, 'Failed to destroy format pool')
+    )
   })
 
   app.listen({ port: PG_META_PORT, host: PG_META_HOST }, (err) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -160,52 +160,19 @@ if (EXPORT_DOCS) {
 } else if (GENERATE_TYPES) {
   console.log(await getTypeOutput())
 } else {
-  const closeListeners = closeWithGrace(async ({ err, signal, manual }) => {
+  // The delay must stay well under container runtimes' stop grace period
+  // (10s by default in Docker), or the process gets SIGKILLed before it can
+  // exit cleanly.
+  closeWithGrace({ delay: 1500 }, async ({ err, signal, manual }) => {
     if (err) {
       app.log.error({ err }, 'server closing with error')
     } else {
-      app.log.error(
-        { err: new Error('Signal Received') },
-        `${signal} signal received, server closing, close manual received: ${manual}`
-      )
+      app.log.info(`${signal} signal received, server closing, close manual received: ${manual}`)
     }
-    try {
-      await app.close()
-    } catch (err) {
-      app.log.error({ err }, `Failed to close app`)
-      throw err
-    }
-    try {
-      await adminApp.close()
-    } catch (err) {
-      app.log.error({ err }, `Failed to close adminApp`)
-      throw err
-    }
-    try {
-      // worker threads keep the event loop alive, so the process would not exit
-      await destroyFormatPool()
-    } catch (err) {
-      app.log.error({ err }, `Failed to destroy format pool`)
-      throw err
-    }
-  })
-  app.addHook('onClose', async () => {
-    try {
-      closeListeners.uninstall()
-      await adminApp.close()
-    } catch (err) {
-      app.log.error({ err }, `Failed to close adminApp in app onClose hook`)
-      throw err
-    }
-  })
-  adminApp.addHook('onClose', async () => {
-    try {
-      closeListeners.uninstall()
-      await app.close()
-    } catch (err) {
-      app.log.error({ err }, `Failed to close app in adminApp onClose hook`)
-      throw err
-    }
+    await app.close().catch((err) => app.log.error({ err }, 'Failed to close app'))
+    await adminApp.close().catch((err) => app.log.error({ err }, 'Failed to close adminApp'))
+    // worker threads keep the event loop alive, so the process would not exit
+    await destroyFormatPool().catch((err) => app.log.error({ err }, 'Failed to destroy format pool'))
   })
 
   app.listen({ port: PG_META_PORT, host: PG_META_HOST }, (err) => {


### PR DESCRIPTION
## Summary
Refactors the server shutdown logic to use a configurable grace period before force-exiting, allowing in-flight work to complete within a timeout window. This improves reliability in containerized environments where the container runtime may SIGKILL the process after its own grace period.

## Key Changes
- **New environment variable**: `PG_META_SHUTDOWN_GRACE_PERIOD_SECS` (default: 10 seconds) controls how long the server waits for in-flight work before force-exiting
- **Simplified shutdown handler**: Removed complex close listener management and mutual app/adminApp hook dependencies that could cause deadlocks
- **Improved error handling**: Changed to use `.catch()` for graceful error handling during shutdown instead of throwing, ensuring all cleanup steps attempt to run
- **Better logging**: Changed signal received log from `error` level to `info` level (more appropriate for normal shutdown signals)
- **Updated documentation**: Added the new environment variable to CLAUDE.md

## Implementation Details
- The `closeWithGrace` call now passes a `delay` option set to `SHUTDOWN_GRACE_PERIOD_MS`
- Removed the `closeListeners` variable and associated hook uninstall logic that was managing listener lifecycle
- Removed circular dependencies between `app.onClose` and `adminApp.onClose` hooks that could prevent proper shutdown
- All cleanup operations (closing app, adminApp, destroying format pool) now use `.catch()` to log errors without throwing, ensuring subsequent cleanup steps execute
- The grace period default (10s) matches Docker's default container stop grace period, with the expectation that this value should be set lower than the container runtime's grace period for the force-exit to actually execute

https://claude.ai/code/session_01Gj9ospbnecaS2ccYt2MayL