### PR TITLE
fix(policies): fall back to public when roles is an empty array

### DIFF
--- a/src/lib/PostgresMetaPolicies.ts
+++ b/src/lib/PostgresMetaPolicies.ts
@@ -142,7 +142,11 @@ CREATE POLICY ${ident(name)} ON ${ident(schema)}.${ident(table)}
     const nameSql = name === undefined ? '' : `${alter} RENAME TO ${ident(name)};`
     const definitionSql = definition === undefined ? '' : `${alter} USING (${definition});`
     const checkSql = check === undefined ? '' : `${alter} WITH CHECK (${check});`
-    const rolesSql = roles === undefined ? '' : `${alter} TO ${roles.map(ident).join(',')};`
+    // An empty array means "all roles", which is the default `create` applies.
+    const rolesSql =
+      roles === undefined
+        ? ''
+        : `${alter} TO ${(roles.length === 0 ? ['public'] : roles).map(ident).join(',')};`
 
     // nameSql must be last
     const sql = `BEGIN; ${definitionSql} ${checkSql} ${rolesSql} ${nameSql} COMMIT;`

--- a/test/lib/policies.ts
+++ b/test/lib/policies.ts
@@ -188,3 +188,24 @@ test('retrieve, create, update, delete', async () => {
     },
   })
 })
+
+test('update roles to an empty array falls back to public', async () => {
+  let res = await pgMeta.policies.create({
+    name: 'test empty roles policy',
+    schema: 'public',
+    table: 'memes',
+    roles: ['postgres'],
+  })
+  const policyId = res.data!.id
+  expect(res.data!.roles).toStrictEqual(['postgres'])
+
+  // An empty array means "all roles" — the same default `create` applies.
+  // `name` is typed as required even though `update` treats it as optional, and
+  // renaming a policy to its own name errors, so it has to be omitted here.
+  res = await pgMeta.policies.update(policyId, { roles: [] } as any)
+
+  expect(res.error).toBeNull()
+  expect(res.data!.roles).toStrictEqual(['public'])
+
+  await pgMeta.policies.remove(policyId)
+})


### PR DESCRIPTION
## Problem

`policies.update()` builds the `TO` clause with `roles.map(ident).join(',')`, which returns an empty string for `[]`. The generated statement becomes:

```sql
ALTER POLICY "test policy" ON public.memes TO ;
```

and Postgres rejects it with `syntax error at or near ";"`.

An empty array is the natural way for a client to express "all roles", and it is what `policies.create()` already defaults to (`roles = ['public']`). The update path only handled `undefined` ("leave roles alone") and never considered `[]`.

## Why this hasn't been hit recently

Studio applies the same fallback client-side before calling the API, in `apps/studio/components/interfaces/Database/Policies/PolicyEditorPanel/index.tsx`:

```ts
const updatedRoles = roles.length === 0 ? ['public'] : roles.split(', ')
```

so the dashboard never sends `[]`. The original dashboard report (supabase/supabase#7740) was resolved by that client-side change, which is why the symptom disappeared while the server-side cause stayed open as #361.

The bug is still reachable for anyone calling the REST API directly or using the published `@supabase/postgres-meta` package. If this lands, Studio's workaround becomes redundant.

## Fix

Treat `[]` as `['public']`, matching `create()`:

| `roles` | meaning | SQL emitted |
| --- | --- | --- |
| `undefined` | leave roles unchanged | *(nothing)* |
| `[]` | all roles | `... TO public;` |
| `['anon']` | those roles | `... TO anon;` |

## Test

`test/lib/policies.ts` creates a policy with `['postgres']`, updates it with `[]`, and expects `['public']`. It fails on `master` with the syntax error above and passes with the change. Full suite: 200/200.

One note on the test: it casts the payload because `update()` types `name` as required, even though the implementation branches on `name === undefined` and the route passes `request.body as any`. Passing the current name isn't a workaround either, since renaming a policy to its own name errors with `policy ... already exists`. I left the type alone to keep this PR to a single change, but happy to follow up with `name?: string` if you'd like it.

Fixes #361
