### PR TITLE
feat: add json output exposing the GeneratorMetadata contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Helpers:
   - [ ] GET `/typescript`: Generate Typescript types
   - [ ] GET `/swift`: Generate Swift types (beta)
   - [ ] GET `/python`: Generate Python types (beta)
+  - [ ] GET `/json`: Dump the raw generator metadata as JSON, for third-party type generators
 
 ## Quickstart
 
@@ -110,6 +111,7 @@ where `<lang>` is one of:
 - `go`
 - `swift` (beta)
 - `python` (beta)
+- `json` (the raw generator metadata all the other generators consume, for building your own generator)
 
 To use your own database connection string instead of the provided test database, run:
 `PG_META_DB_URL=postgresql://postgres:postgres@localhost:5432/postgres npm run gen:types:<lang>`

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gen:types:go": "PG_META_GENERATE_TYPES=go node --loader ts-node/esm src/server/server.ts",
     "gen:types:swift": "PG_META_GENERATE_TYPES=swift node --loader ts-node/esm src/server/server.ts",
     "gen:types:python": "PG_META_GENERATE_TYPES=python node --loader ts-node/esm src/server/server.ts",
+    "gen:types:json": "PG_META_GENERATE_TYPES=json node --loader ts-node/esm src/server/server.ts",
     "start": "node dist/server/server.js",
     "dev": "trap 'npm run db:clean' INT && run-s db:clean db:run &&  run-s dev:code",
     "dev:code": "nodemon --exec node --loader ts-node/esm src/server/server.ts | pino-pretty --colorize",

--- a/src/server/routes/generators/json.ts
+++ b/src/server/routes/generators/json.ts
@@ -1,0 +1,35 @@
+import type { FastifyInstance } from 'fastify'
+import { PostgresMeta } from '../../../lib/index.js'
+import { createConnectionConfig, extractRequestForLogging } from '../../utils.js'
+import { getGeneratorMetadata } from '../../../lib/generators.js'
+
+export default async (fastify: FastifyInstance) => {
+  fastify.get<{
+    Headers: { pg: string; 'x-pg-application-name'?: string }
+    Querystring: {
+      excluded_schemas?: string
+      included_schemas?: string
+    }
+  }>('/', async (request, reply) => {
+    const config = createConnectionConfig(request)
+    const excludedSchemas =
+      request.query.excluded_schemas?.split(',').map((schema) => schema.trim()) ?? []
+    const includedSchemas =
+      request.query.included_schemas?.split(',').map((schema) => schema.trim()) ?? []
+
+    const pgMeta: PostgresMeta = new PostgresMeta(config)
+    const { data: generatorMeta, error: generatorMetaError } = await getGeneratorMetadata(pgMeta, {
+      includedSchemas,
+      excludedSchemas,
+    })
+    if (generatorMetaError) {
+      request.log.error({ error: generatorMetaError, request: extractRequestForLogging(request) })
+      reply.code(500)
+      return { error: generatorMetaError.message }
+    }
+
+    // The raw `GeneratorMetadata` contract of @supabase/postgrest-typegen,
+    // for third-party type generators (e.g. supabase_typegen for Dart).
+    return reply.type('application/json').send(JSON.stringify(generatorMeta, null, 2))
+  })
+}

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -22,6 +22,7 @@ import TypeScriptTypeGenRoute from './generators/typescript.js'
 import GoTypeGenRoute from './generators/go.js'
 import SwiftTypeGenRoute from './generators/swift.js'
 import PythonTypeGenRoute from './generators/python.js'
+import JsonTypeGenRoute from './generators/json.js'
 import { PG_CONNECTION, CRYPTO_KEY } from '../constants.js'
 
 export default async (fastify: FastifyInstance) => {
@@ -84,4 +85,5 @@ export default async (fastify: FastifyInstance) => {
   fastify.register(GoTypeGenRoute, { prefix: '/generators/go' })
   fastify.register(SwiftTypeGenRoute, { prefix: '/generators/swift' })
   fastify.register(PythonTypeGenRoute, { prefix: '/generators/python' })
+  fastify.register(JsonTypeGenRoute, { prefix: '/generators/json' })
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -66,6 +66,10 @@ async function getTypeOutput(): Promise<string | null> {
       return generateGo(generatorMetadata!)
     case 'python':
       return generatePython(generatorMetadata!)
+    case 'json':
+      // The raw GeneratorMetadata contract of @supabase/postgrest-typegen,
+      // for third-party type generators.
+      return JSON.stringify(generatorMetadata, null, 2)
     default:
       throw new Error(`Unsupported language for GENERATE_TYPES: ${GENERATE_TYPES}`)
   }

--- a/test/server/typegen.ts
+++ b/test/server/typegen.ts
@@ -6964,3 +6964,82 @@ test('typegen: python w/ excluded/included schemas', async () => {
     })
   }
 })
+
+test('typegen: json', async () => {
+  const response = await app.inject({ method: 'GET', path: '/generators/json' })
+  expect(response.statusCode).toBe(200)
+  expect(response.headers['content-type']).toContain('application/json')
+
+  const metadata = JSON.parse(response.body)
+  expect(Object.keys(metadata).sort()).toEqual(
+    [
+      'schemas',
+      'tables',
+      'foreignTables',
+      'views',
+      'materializedViews',
+      'columns',
+      'relationships',
+      'functions',
+      'types',
+    ].sort()
+  )
+
+  // The whole point of this endpoint is introspection fidelity that lossy
+  // sources (like the PostgREST OpenAPI description) cannot provide, so
+  // assert that nullability, defaults, and identity information survive.
+  const usersStatus = metadata.columns.find(
+    (column: any) =>
+      column.schema === 'public' && column.table === 'users' && column.name === 'status'
+  )
+  expect(usersStatus).toMatchObject({
+    is_nullable: true,
+    default_value: "'ACTIVE'::user_status",
+    data_type: 'USER-DEFINED',
+    format: 'user_status',
+  })
+
+  const usersId = metadata.columns.find(
+    (column: any) => column.schema === 'public' && column.table === 'users' && column.name === 'id'
+  )
+  expect(usersId).toMatchObject({
+    is_nullable: false,
+    is_identity: true,
+    identity_generation: 'BY DEFAULT',
+  })
+
+  const userStatusEnum = metadata.types.find(
+    (type: any) => type.schema === 'public' && type.name === 'user_status'
+  )
+  expect(userStatusEnum.enums).toEqual(['ACTIVE', 'INACTIVE'])
+
+  const todosView = metadata.views.find(
+    (view: any) => view.schema === 'public' && view.name === 'todos_view'
+  )
+  expect(todosView).toBeDefined()
+
+  const todosMatview = metadata.materializedViews.find(
+    (view: any) => view.schema === 'public' && view.name === 'todos_matview'
+  )
+  expect(todosMatview).toBeDefined()
+})
+
+test('typegen: json w/ excluded/included schemas', async () => {
+  const { body: excludedBody } = await app.inject({
+    method: 'GET',
+    path: '/generators/json',
+    query: { excluded_schemas: 'public' },
+  })
+  const excludedMetadata = JSON.parse(excludedBody)
+  expect(excludedMetadata.tables).toEqual([])
+  expect(excludedMetadata.schemas.map((schema: any) => schema.name)).not.toContain('public')
+
+  const { body: includedBody } = await app.inject({
+    method: 'GET',
+    path: '/generators/json',
+    query: { included_schemas: 'public' },
+  })
+  const includedMetadata = JSON.parse(includedBody)
+  expect(includedMetadata.schemas.map((schema: any) => schema.name)).toEqual(['public'])
+  expect(includedMetadata.tables.map((table: any) => table.name)).toContain('users')
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, stacked on #1084 (base branch is its `claude/funny-tesla-wofjdj` head; only the last commit is new). Adds a `json` output alongside typescript, go, swift, and python, emitting the raw `GeneratorMetadata` contract of `@supabase/postgrest-typegen` that #1084 makes postgres-meta consume.

## What is the new behavior?

- `GET /generators/json` returns the introspected `GeneratorMetadata` (schemas, tables, foreign tables, views, materialized views, columns, relationships, functions, types) as pretty-printed JSON, with the same `included_schemas`/`excluded_schemas` query parameters as the other generators.
- `PG_META_GENERATE_TYPES=json` (and the `gen:types:json` npm script) emits the same document on stdout, so the Supabase CLI can expose it as `supabase gen types --lang json` and pipe it into out-of-process generators as `--lang dart` (supabase/cli#6230, supabase/supabase-flutter#1635 whose parser consumes exactly this contract).

This gives third-party and community type generators a single high-fidelity, language-neutral introspection source: exact nullability, database defaults, identity and generated columns, enum values, views, and materialized views, which lossy sources like the PostgREST OpenAPI description cannot provide.

## Additional context

- The output is a plain `JSON.stringify` over the `sortGeneratorMetadata`-canonicalized introspection result, so it adds no new queries and stays in sync with whatever the built-in generators see.
- Supersedes #1106 (closed as a duplicate of the #1084 extraction): same endpoint surface, now backed by the package instead of the deleted in-repo metadata assembly. Unlike #1106 this emits the bare contract without a `version` envelope; whether the serialized contract should carry one is raised on the postgrest-typegen RFC.
- Tests assert the envelope keys and the fidelity data that motivate the endpoint (nullability, defaults, identity, enum values, views, materialized views), plus schema filtering. The full suite passes locally with the same pre-existing environment-specific failures as `master` (SSL and query-timeout tests).