### PR TITLE
fix: retrieve the zero-argument function overload when args is empty

### DIFF
--- a/src/lib/sql/functions.sql.ts
+++ b/src/lib/sql/functions.sql.ts
@@ -38,10 +38,9 @@ with functions as (
     ${
       props.args === undefined
         ? ''
-        : props.args.length > 0
-          ? `p.proargtypes::text = ${
-              props.args.length
-                ? `(
+        : `p.proargtypes::text = ${
+            props.args.length > 0
+              ? `(
           SELECT STRING_AGG(type_oid::text, ' ') FROM (
             SELECT (
               split_args.arr[
@@ -60,9 +59,8 @@ with functions as (
             ) AS split_args
           ) args
     )`
-                : "''"
-            } AND`
-          : ''
+              : "''"
+          } AND`
     }
     p.prokind = 'f'
 )

--- a/test/lib/functions.ts
+++ b/test/lib/functions.ts
@@ -531,3 +531,19 @@ test('retrieve function by args filter - function with no arguments', async () =
   })
   expect(res.error).toBeNull()
 })
+
+test('retrieve function by args filter - zero-argument overload among polymorphic functions', async () => {
+  const res = await pgMeta.functions.retrieve({
+    schema: 'public',
+    name: 'polymorphic_function_with_no_params_or_unnamed',
+    args: [],
+  })
+  expect(res.error).toBeNull()
+  expect(res.data).toMatchObject({
+    name: 'polymorphic_function_with_no_params_or_unnamed',
+    schema: 'public',
+    argument_types: '',
+    args: [],
+    return_type: 'integer',
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## Why?

`functions.retrieve({ schema, name, args: [] })` is documented by the existing tests as selecting the zero-argument overload. `FUNCTIONS_SQL` skipped the `proargtypes` predicate whenever `args` was empty, so overloaded names returned `data[0]` instead of the no-arg signature.

`functions.create()` looks the function up the same way after `CREATE FUNCTION`, so creating a zero-argument overload of an existing name could also return the wrong row.

Fixes #1111.

## How?

When `args` is provided, always filter on `p.proargtypes::text`. Non-empty argument lists still resolve type OIDs the same way; `args: []` now compares against the empty `oidvector` (`''`), which was already present as dead code.

## Checklist

- [x] Bug fix
- [x] Tests added
- [ ] Docs
- [ ] Breaking change

## New tests

`retrieve function by args filter - zero-argument overload among polymorphic functions` uses the existing `polymorphic_function_with_no_params_or_unnamed` fixtures. Before the fix it received the `text` overload; after the fix it receives the zero-argument `integer` overload.
