### PR TITLE
fix: do not paginate columns when listing materialized views

### DIFF
--- a/src/lib/PostgresMetaMaterializedViews.ts
+++ b/src/lib/PostgresMetaMaterializedViews.ts
@@ -98,7 +98,7 @@ const generateEnrichedMaterializedViewsSql = ({
   offset?: number
 }) => `
 with materialized_views as (${MATERIALIZED_VIEWS_SQL({ schemaFilter, limit, offset, materializedViewIdentifierFilter, idsFilter })})
-  ${includeColumns ? `, columns as (${COLUMNS_SQL({ schemaFilter, limit, offset, tableIdentifierFilter: materializedViewIdentifierFilter, tableIdFilter: idsFilter })})` : ''}
+  ${includeColumns ? `, columns as (${COLUMNS_SQL({ schemaFilter, tableIdentifierFilter: materializedViewIdentifierFilter, tableIdFilter: idsFilter })})` : ''}
 select
   *
   ${

--- a/test/server/materialized-views.ts
+++ b/test/server/materialized-views.ts
@@ -100,3 +100,19 @@ test('materialized views with columns', async () => {
     ]
   `)
 })
+
+test('materialized views with columns keep every column when listing with limit', async () => {
+  const { body } = await app.inject({
+    method: 'GET',
+    path: '/materialized-views',
+    query: { include_columns: 'true', limit: '1' },
+  })
+  const data = JSON.parse(body)
+  expect(data).toHaveLength(1)
+  expect(data[0].name).toBe('todos_matview')
+  expect(data[0].columns.map((column: { name: string }) => column.name)).toEqual([
+    'id',
+    'details',
+    'user-id',
+  ])
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## Why?

`GET /materialized-views?include_columns=true&limit=N` forwarded `limit`/`offset` into `COLUMNS_SQL`. That paginates every column in the database, not columns of the selected matviews, so a limited list can return empty or truncated `columns` arrays.

Tables, views, and foreign tables already paginate only the relation CTE.

Fixes #1113.

## How?

Stop passing `limit`/`offset` into the columns CTE in `generateEnrichedMaterializedViewsSql`.

## Checklist

- [x] Bug fix
- [x] Tests added
- [ ] Docs
- [ ] Breaking change
