### PR TITLE
fix: preserve identity generation when it is omitted from column updates

### DIFF
--- a/src/lib/PostgresMetaColumns.ts
+++ b/src/lib/PostgresMetaColumns.ts
@@ -191,7 +191,7 @@ COMMIT;`
       default_value,
       default_value_format = 'literal',
       is_identity,
-      identity_generation = 'BY DEFAULT',
+      identity_generation,
       is_nullable,
       is_unique,
       comment,
@@ -265,7 +265,7 @@ COMMIT;`
     } else if (is_identity === undefined) {
       identitySql = ''
     } else {
-      identitySql += ` ADD GENERATED ${identity_generation} AS IDENTITY;`
+      identitySql += ` ADD GENERATED ${identity_generation ?? 'BY DEFAULT'} AS IDENTITY;`
     }
     let isNullableSql: string
     if (is_nullable === undefined) {

--- a/test/lib/columns.ts
+++ b/test/lib/columns.ts
@@ -1017,3 +1017,29 @@ test('column with fully-qualified type', async () => {
 
   await pgMeta.query(`drop table public.t; drop schema s cascade;`)
 })
+
+test('updating a comment does not rewrite ALWAYS identity to BY DEFAULT', async () => {
+  const { data: table, error: tableError } = await pgMeta.tables.create({
+    name: 't_identity_comment_update',
+  })
+  expect(tableError).toBeNull()
+
+  try {
+    const created = await pgMeta.columns.create({
+      table_id: table!.id,
+      name: 'id',
+      type: 'int8',
+      is_identity: true,
+      identity_generation: 'ALWAYS',
+    })
+    expect(created.error).toBeNull()
+    expect(created.data!.identity_generation).toBe('ALWAYS')
+
+    const updated = await pgMeta.columns.update(created.data!.id, { comment: 'pk' })
+    expect(updated.error).toBeNull()
+    expect(updated.data!.identity_generation).toBe('ALWAYS')
+    expect(updated.data!.comment).toBe('pk')
+  } finally {
+    await pgMeta.tables.remove(table!.id, { cascade: true })
+  }
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## Why?

`columns.update` defaulted `identity_generation` to `'BY DEFAULT'`. The in-file state table says that omitting it on an existing identity column should emit no `SET GENERATED`, but the default made that branch unreachable. A comment-only PATCH therefore rewrote `GENERATED ALWAYS` to `BY DEFAULT`.

`POST /columns` still defaults omitted generation to `BY DEFAULT` (#77).

Fixes #1114.

## How?

Remove the update-path default. Keep `SET GENERATED` only when `identity_generation` is provided. When adding identity, fall back to `BY DEFAULT` if generation is omitted.

## Checklist

- [x] Bug fix
- [x] Tests added
- [ ] Docs
- [ ] Breaking change
