### PR TITLE
fix: preserve equals signs in role config values

### DIFF
--- a/src/lib/PostgresMetaRoles.ts
+++ b/src/lib/PostgresMetaRoles.ts
@@ -24,7 +24,9 @@ export function changeRoleConfig2Object(config: string[]) {
     return null
   }
   return config.reduce((acc: any, cur) => {
-    const [key, value] = cur.split('=')
+    const separator = cur.indexOf('=')
+    const key = separator === -1 ? cur : cur.slice(0, separator)
+    const value = separator === -1 ? undefined : cur.slice(separator + 1)
     acc[key] = value
     return acc
   }, {})

--- a/test/roles-config.test.ts
+++ b/test/roles-config.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'vitest'
+import { changeRoleConfig2Object } from '../src/lib/PostgresMetaRoles.js'
+
+describe('changeRoleConfig2Object', () => {
+  test('preserves equals signs within role config values', () => {
+    expect(changeRoleConfig2Object(['application_name=api=worker', 'search_path=public'])).toEqual({
+      application_name: 'api=worker',
+      search_path: 'public',
+    })
+  })
+
+  test('preserves existing parsing for entries without a separator', () => {
+    expect(changeRoleConfig2Object(['search_path'])).toEqual({ search_path: undefined })
+  })
+})


### PR DESCRIPTION
Fixes #1117

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Role configuration parsing splits each rolconfig entry on every equals sign and keeps only the first value segment. A value such as application_name=api=worker is returned as api.

## What is the new behavior?

The parser treats only the first equals sign as the key/value delimiter and preserves the rest of the value verbatim. Existing behavior for ordinary and delimiter-free entries remains unchanged.

## Tests

Added focused coverage for values containing additional equals signs and for the existing delimiter-free behavior.

Local validation:

- npx vitest run test/roles-config.test.ts — 2 passed
- npm run check — passed
- npm run build — passed
- Prettier check — passed
- git diff --check — passed

Docker-backed integration tests were unavailable because the local Docker daemon is not running.

## Additional context

Open #1091 touches a separate null guard in role config updates; it does not change rolconfig response parsing.