### PR TITLE
fix: apply idsFilter when retrieving a foreign table by id

### DIFF
--- a/src/lib/PostgresMetaForeignTables.ts
+++ b/src/lib/PostgresMetaForeignTables.ts
@@ -111,7 +111,7 @@ const generateEnrichedForeignTablesSql = ({
   limit?: number
   offset?: number
 }) => `
-with foreign_tables as (${FOREIGN_TABLES_SQL({ schemaFilter, tableIdentifierFilter, limit, offset })})
+with foreign_tables as (${FOREIGN_TABLES_SQL({ schemaFilter, tableIdentifierFilter, idsFilter, limit, offset })})
   ${includeColumns ? `, columns as (${COLUMNS_SQL({ schemaFilter, tableIdentifierFilter, tableIdFilter: idsFilter })})` : ''}
 select
   *

--- a/test/lib/foreign-tables.ts
+++ b/test/lib/foreign-tables.ts
@@ -173,3 +173,32 @@ test('retrieve', async () => {
     }
   `)
 })
+
+test('retrieve by id returns the matching foreign table among several', async () => {
+  await pgMeta.query(`
+    create foreign table public.foreign_table_2 (
+      id int8 not null
+    ) server foreign_server options (schema_name 'public', table_name 'users');
+  `)
+
+  try {
+    const listed = await pgMeta.foreignTables.list({ includeColumns: false })
+    const first = listed.data!.find(({ name }) => name === 'foreign_table')
+    const second = listed.data!.find(({ name }) => name === 'foreign_table_2')
+    expect(first).toBeTruthy()
+    expect(second).toBeTruthy()
+    expect(first!.id).not.toBe(second!.id)
+
+    const retrievedSecond = await pgMeta.foreignTables.retrieve({ id: second!.id })
+    expect(retrievedSecond.error).toBeNull()
+    expect(retrievedSecond.data!.name).toBe('foreign_table_2')
+    expect(retrievedSecond.data!.id).toBe(second!.id)
+
+    const retrievedFirst = await pgMeta.foreignTables.retrieve({ id: first!.id })
+    expect(retrievedFirst.error).toBeNull()
+    expect(retrievedFirst.data!.name).toBe('foreign_table')
+    expect(retrievedFirst.data!.id).toBe(first!.id)
+  } finally {
+    await pgMeta.query(`drop foreign table if exists public.foreign_table_2`)
+  }
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## Why?

`foreignTables.retrieve({ id })` built `idsFilter` but never passed it to `FOREIGN_TABLES_SQL`. With more than one foreign table, `GET /foreign-tables/:id` returned `data[0]` instead of the requested OID.

Fixes #1121.

## How?

Forward `idsFilter` into `FOREIGN_TABLES_SQL`, matching views/tables/materialized views.

## Checklist

- [x] Bug fix
- [x] Tests added
- [ ] Docs
- [ ] Breaking change
