### PR TITLE
fix: quote schema-qualified array types when adding columns

### DIFF
--- a/src/lib/PostgresMetaColumns.ts
+++ b/src/lib/PostgresMetaColumns.ts
@@ -404,9 +404,16 @@ COMMIT;`
 // TODO: make this more robust - use type_id or type_schema + type_name instead
 // of just type.
 const typeIdent = (type: string) => {
-  return type.endsWith('[]')
-    ? `${ident(type.slice(0, -2))}[]`
-    : type.includes('.')
-      ? type
-      : ident(type)
+  const isArray = type.endsWith('[]')
+  const base = isArray ? type.slice(0, -2) : type
+  if (!base.includes('.')) {
+    return isArray ? `${ident(base)}[]` : ident(base)
+  }
+  if (isArray) {
+    return `${base
+      .split('.')
+      .map((part) => ident(part))
+      .join('.')}[]`
+  }
+  return base
 }

--- a/test/lib/columns.ts
+++ b/test/lib/columns.ts
@@ -1017,3 +1017,36 @@ test('column with fully-qualified type', async () => {
 
   await pgMeta.query(`drop table public.t; drop schema s cascade;`)
 })
+
+test('column with schema-qualified array type', async () => {
+  await pgMeta.query(
+    `drop table if exists public.t_schema_array; drop schema if exists s_schema_array cascade;`
+  )
+  await pgMeta.query(
+    `create table public.t_schema_array(); create schema s_schema_array; create type s_schema_array.my_type as enum ('a');`
+  )
+
+  try {
+    const table = await pgMeta.tables.retrieve({
+      schema: 'public',
+      name: 't_schema_array',
+    })
+    const created = await pgMeta.columns.create({
+      table_id: table.data!.id,
+      name: 'c',
+      type: 's_schema_array.my_type[]',
+    })
+    expect(created.error).toBeNull()
+    expect(created.data).toMatchObject({
+      name: 'c',
+      format: '_my_type',
+      data_type: 'ARRAY',
+      schema: 'public',
+      table: 't_schema_array',
+    })
+  } finally {
+    await pgMeta.query(
+      `drop table if exists public.t_schema_array; drop schema if exists s_schema_array cascade;`
+    )
+  }
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## Why?

`typeIdent('schema.type[]')` quoted the whole `schema.type` as one identifier (`"schema.type"[]`). Postgres then cannot resolve the array type. Non-array schema-qualified names are unchanged.

Fixes #1122.

## How?

For array types that include `.`, quote each identifier component separately (`"schema"."type"[]`).

## Checklist

- [x] Bug fix
- [x] Tests added
- [ ] Docs
- [ ] Breaking change
