### PR TITLE
fix(typegen): escape Go struct tags

### DIFF
--- a/src/server/templates/go.ts
+++ b/src/server/templates/go.ts
@@ -112,6 +112,11 @@ function formatForGoTypeName(name: string): string {
     .join('')
 }
 
+function formatForGoStructTag(name: string): string {
+  const tag = `json:${JSON.stringify(name)}`
+  return name.includes('`') ? JSON.stringify(tag) : `\`${tag}\``
+}
+
 function generateTableStruct(
   schema: PostgresSchema,
   table: PostgresTable | PostgresView | PostgresMaterializedView,
@@ -157,7 +162,7 @@ function generateTableStruct(
   const formattedColumnEntries = columnEntries.map(([formattedName, type, name]) => {
     return `  ${formattedName.padEnd(maxFormattedNameLength)} ${type.padEnd(
       maxTypeLength
-    )} \`json:"${name}"\``
+    )} ${formatForGoStructTag(name)}`
   })
 
   return `
@@ -215,7 +220,7 @@ function generateCompositeTypeStruct(
   const formattedAttributeEntries = attributeEntries.map(([formattedName, type, name]) => {
     return `  ${formattedName.padEnd(maxFormattedNameLength)} ${type.padEnd(
       maxTypeLength
-    )} \`json:"${name}"\``
+    )} ${formatForGoStructTag(name)}`
   })
 
   return `

--- a/test/server/templates/go.test.ts
+++ b/test/server/templates/go.test.ts
@@ -104,3 +104,41 @@ describe('go typegen pgTypeToGoType array fallback', () => {
     expect(result).toMatch(/Tags\s+\[]string\b/)
   })
 })
+
+describe('go typegen struct tag escaping', () => {
+  test('uses an interpreted struct tag when a column name contains a backtick', () => {
+    const result = apply(
+      buildMetadata([baseColumn({ name: `back${String.fromCharCode(96)}tick`, format: 'text' })])
+    )
+
+    expect(result).toContain('BackTick string "json:\\"back`tick\\""')
+  })
+
+  test('preserves raw struct tags for ordinary column names', () => {
+    const result = apply(buildMetadata([baseColumn({ name: 'display_name', format: 'text' })]))
+
+    expect(result).toContain('DisplayName string `json:"display_name"`')
+  })
+
+  test('escapes composite type attribute tags', () => {
+    const textType = {
+      id: 101,
+      name: 'text',
+      schema: 'pg_catalog',
+      format: 'text',
+      enums: [],
+      attributes: [],
+    } as PostgresType
+    const compositeType = {
+      id: 102,
+      name: 'details',
+      schema: 'public',
+      format: 'details',
+      enums: [],
+      attributes: [{ name: `back${String.fromCharCode(96)}tick`, type_id: textType.id }],
+    } as PostgresType
+    const result = apply({ ...buildMetadata([]), types: [textType, compositeType] })
+
+    expect(result).toContain('BackTick string "json:\\"back`tick\\""')
+  })
+})


### PR DESCRIPTION
## Summary

- preserve PostgreSQL column and composite-attribute names in valid Go struct tags
- keep the existing raw-tag output for ordinary names and use an interpreted literal only when a backtick requires it
- add focused regression coverage for table columns, composite attributes, and ordinary tags

## Problem

PostgreSQL quoted identifiers can contain backticks. The Go generator interpolated column names directly into raw struct-tag literals, so a name containing a backtick terminated the literal and produced source that `gofmt` rejected.

## Root cause

Both table-column and composite-attribute paths emitted `json` tags without escaping the database-provided name or accounting for the raw literal delimiter.

## Solution

Build the `json` tag value with JSON-compatible quoting. Continue using the current raw Go literal when possible, and emit an interpreted Go literal when the value contains a backtick.

## Tests and validation

- `npx vitest run test/server/templates/go.test.ts` — 6 passed
- generated backtick-name fixture piped to `gofmt` — passed
- `npm run check` — passed
- `npm run build` — passed
- `npx prettier --check src/server/templates/go.ts test/server/templates/go.test.ts` — passed
- `git diff --check` — passed
- Docker-backed suite — 199 passed, 2 unrelated failures on this Node 24 host; the SSL message mismatch also fails on untouched `origin/master`, while the oversized-result timeout passed on the untouched baseline

## Compatibility and risk

Ordinary generated tags retain their previous representation. The change is limited to tag serialization and does not alter field naming or Go type mapping.

## Documentation

No documentation change is needed because this restores valid generated output for supported PostgreSQL identifiers.

Fixes #1125