### PR TITLE
fix(typegen): escape Swift string literals

### DIFF
--- a/src/server/templates/swift.ts
+++ b/src/server/templates/swift.ts
@@ -153,6 +153,36 @@ function generateProtocolConformances(protocols: string[]): string {
   return protocols.length === 0 ? '' : `: ${protocols.join(', ')}`
 }
 
+function swiftStringLiteral(value: string): string {
+  let escaped = ''
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!
+    switch (character) {
+      case '\\':
+        escaped += '\\\\'
+        break
+      case '"':
+        escaped += '\\"'
+        break
+      case '\t':
+        escaped += '\\t'
+        break
+      case '\n':
+        escaped += '\\n'
+        break
+      case '\r':
+        escaped += '\\r'
+        break
+      default:
+        escaped +=
+          codePoint < 0x20 || codePoint === 0x7f || codePoint === 0x2028 || codePoint === 0x2029
+            ? `\\u{${codePoint.toString(16)}}`
+            : character
+    }
+  }
+  return `"${escaped}"`
+}
+
 function generateEnum(
   enum_: SwiftEnum,
   { accessControl, level }: SwiftGeneratorOptions & { level: number }
@@ -160,7 +190,8 @@ function generateEnum(
   return [
     `${ident(level)}${accessControl} enum ${enum_.formattedEnumName}${generateProtocolConformances(enum_.protocolConformances)} {`,
     ...enum_.cases.map(
-      (case_) => `${ident(level + 1)}case ${case_.formattedName} = "${case_.rawValue}"`
+      (case_) =>
+        `${ident(level + 1)}case ${case_.formattedName} = ${swiftStringLiteral(case_.rawValue)}`
     ),
     `${ident(level)}}`,
   ]

--- a/test/server/templates/swift.test.ts
+++ b/test/server/templates/swift.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest'
+
+import { apply } from '../../../src/server/templates/swift'
+import type { GeneratorMetadata } from '../../../src/lib/generators'
+import type {
+  PostgresColumn,
+  PostgresSchema,
+  PostgresTable,
+  PostgresType,
+} from '../../../src/lib/types'
+
+const baseSchema: PostgresSchema = {
+  id: 1,
+  name: 'public',
+  owner: 'postgres',
+}
+
+const baseTable = {
+  id: 1,
+  schema: 'public',
+  name: 'tickets',
+} as unknown as Omit<PostgresTable, 'columns'>
+
+const baseColumn = (name: string): PostgresColumn =>
+  ({
+    table_id: 1,
+    name,
+    format: 'text',
+    is_identity: false,
+    is_generated: false,
+    is_nullable: false,
+    default_value: null,
+  }) as PostgresColumn
+
+const enumType = (enums: string[]): PostgresType =>
+  ({
+    id: 100,
+    name: 'status',
+    schema: 'public',
+    format: 'status',
+    enums,
+    attributes: [],
+  }) as PostgresType
+
+const buildMetadata = (overrides: Partial<GeneratorMetadata> = {}) => ({
+  schemas: [baseSchema],
+  tables: [baseTable],
+  foreignTables: [],
+  views: [],
+  materializedViews: [],
+  columns: [],
+  relationships: [],
+  functions: [],
+  types: [],
+  accessControl: 'internal' as const,
+  ...overrides,
+})
+
+describe('swift typegen string literal escaping', () => {
+  test('escapes enum raw values', async () => {
+    const result = await apply(buildMetadata({ types: [enumType(['say"hi', 'use\\path'])] }))
+
+    expect(result).toContain('case sayHi = "say\\"hi"')
+    expect(result).toContain('case usePath = "use\\\\path"')
+  })
+
+  test('escapes coding key raw values', async () => {
+    const result = await apply(buildMetadata({ columns: [baseColumn('say"hi')] }))
+
+    expect(result).toContain('case sayHi = "say\\"hi"')
+  })
+
+  test('escapes newlines and string interpolation markers', async () => {
+    const result = await apply(
+      buildMetadata({ types: [enumType(['line\nbreak', 'value\\(call)'])] })
+    )
+
+    expect(result).toContain('case lineBreak = "line\\nbreak"')
+    expect(result).toContain('case valueCall = "value\\\\(call)"')
+  })
+})


### PR DESCRIPTION
## Summary

- escape database-provided enum raw values and CodingKeys raw values as valid Swift string literals
- cover quotes, backslashes, newlines, and interpolation markers
- add focused regression tests and compiler-parse validation

## Problem

PostgreSQL identifiers and enum labels can contain characters that are special inside Swift strings. The Swift generator interpolated those values directly, allowing quotes to terminate literals and backslash-parenthesis sequences to become interpolation.

## Root cause

The shared enum serializer emitted raw values between quotes without escaping. That serializer is used for both PostgreSQL enums and generated CodingKeys.

## Solution

Add a local Swift string-literal serializer that escapes quotes, backslashes, tabs, line endings, control characters, and Unicode line separators, then use it at the shared enum serialization seam.

## Tests and validation

- `npx vitest run test/server/templates/swift.test.ts` — 3 passed
- generated quote/interpolation fixture piped to `swiftc -parse -` — passed
- `npm run check` — passed
- `npm run build` — passed
- `npx prettier --check src/server/templates/swift.ts test/server/templates/swift.test.ts` — passed
- `git diff --check` — passed
- Docker-backed suite — 199 passed; 2 unrelated failures and 1 skip occurred in the changed run. Untouched `origin/master` reproduced the Node 24 SSL-message failure, while the trigger snapshot and result-size setup passed there, indicating environmental flakiness outside the changed generator path

## Compatibility and risk

Ordinary values serialize identically. Escaping changes only source representation; decoded enum and CodingKeys raw values remain the original PostgreSQL strings.

## Documentation

No documentation change is needed because this restores valid generated output for supported PostgreSQL values.

Fixes #1126