### PR TITLE
fix: keep the whole role config value after the first equals sign

### DIFF
--- a/src/lib/PostgresMetaRoles.ts
+++ b/src/lib/PostgresMetaRoles.ts
@@ -24,8 +24,8 @@ export function changeRoleConfig2Object(config: string[]) {
     return null
   }
   return config.reduce((acc: any, cur) => {
-    const [key, value] = cur.split('=')
-    acc[key] = value
+    const [key, ...rest] = cur.split('=')
+    acc[key] = rest.length > 0 ? rest.join('=') : undefined
     return acc
   }, {})
 }

--- a/test/role-config.test.ts
+++ b/test/role-config.test.ts
@@ -1,0 +1,30 @@
+import { expect, test, describe } from 'vitest'
+import { changeRoleConfig2Object } from '../src/lib/PostgresMetaRoles.js'
+
+describe('changeRoleConfig2Object', () => {
+  test('keeps everything after the first equals sign', () => {
+    expect(changeRoleConfig2Object(['application_name=api=worker'])).toStrictEqual({
+      application_name: 'api=worker',
+    })
+  })
+
+  test('parses ordinary values unchanged', () => {
+    expect(changeRoleConfig2Object(['search_path=public'])).toStrictEqual({
+      search_path: 'public',
+    })
+  })
+
+  test('handles both kinds of entry together', () => {
+    expect(
+      changeRoleConfig2Object(['application_name=api=worker', 'search_path=public'])
+    ).toStrictEqual({ application_name: 'api=worker', search_path: 'public' })
+  })
+
+  test('an entry without an equals sign has no value', () => {
+    expect(changeRoleConfig2Object(['lone_key'])).toStrictEqual({ lone_key: undefined })
+  })
+
+  test('returns null when there is no config', () => {
+    expect(changeRoleConfig2Object(null as unknown as string[])).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #1117.

`changeRoleConfig2Object` destructures `cur.split('=')` into two variables, so everything after the second equals sign is discarded. A `rolconfig` entry like `application_name=api=worker` comes back as `application_name: api`.

Postgres only treats the first equals sign as the separator between the setting name and its value. The rest belongs to the GUC value and should round-trip unchanged.

Fixed by keeping the remainder of the split and rejoining it. An entry with no equals sign still gives `undefined`, exactly as before.

Five unit tests in `test/role-config.test.ts`. They import the function directly and need no database, so they run without the Docker setup. Two of them fail without the change and the other three pass either way, which pins the existing behaviour as well as the fix.

`tsc -p tsconfig.json --noEmit` and `prettier --check` are both clean.
