### PR TITLE
fix: escape backticks in generated Go struct tags

### DIFF
--- a/src/server/templates/go.ts
+++ b/src/server/templates/go.ts
@@ -112,6 +112,16 @@ function formatForGoTypeName(name: string): string {
     .join('')
 }
 
+// Go raw string literals cannot contain a backtick, so a column name with one
+// has to be emitted as an interpreted literal instead.
+function formatGoStructTag(name: string): string {
+  const tag = `json:"${name}"`
+  if (!tag.includes('`')) {
+    return `\`${tag}\``
+  }
+  return `"${tag.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
 function generateTableStruct(
   schema: PostgresSchema,
   table: PostgresTable | PostgresView | PostgresMaterializedView,
@@ -157,7 +167,7 @@ function generateTableStruct(
   const formattedColumnEntries = columnEntries.map(([formattedName, type, name]) => {
     return `  ${formattedName.padEnd(maxFormattedNameLength)} ${type.padEnd(
       maxTypeLength
-    )} \`json:"${name}"\``
+    )} ${formatGoStructTag(name)}`
   })
 
   return `
@@ -215,7 +225,7 @@ function generateCompositeTypeStruct(
   const formattedAttributeEntries = attributeEntries.map(([formattedName, type, name]) => {
     return `  ${formattedName.padEnd(maxFormattedNameLength)} ${type.padEnd(
       maxTypeLength
-    )} \`json:"${name}"\``
+    )} ${formatGoStructTag(name)}`
   })
 
   return `

--- a/test/server/templates/go.test.ts
+++ b/test/server/templates/go.test.ts
@@ -104,3 +104,24 @@ describe('go typegen pgTypeToGoType array fallback', () => {
     expect(result).toMatch(/Tags\s+\[]string\b/)
   })
 })
+
+describe('go typegen struct tags', () => {
+  test('a column name containing a backtick is emitted as an interpreted literal', () => {
+    const result = apply(buildMetadata([baseColumn({ name: 'bad`tag' })]))
+
+    expect(result).toContain('"json:\\"bad`tag\\""')
+    expect(result).not.toContain('`json:"bad`tag"`')
+  })
+
+  test('double quotes are escaped alongside the backtick', () => {
+    const result = apply(buildMetadata([baseColumn({ name: 'a"b`c' })]))
+
+    expect(result).toContain('"json:\\"a\\"b`c\\""')
+  })
+
+  test('ordinary column names keep the raw literal form', () => {
+    const result = apply(buildMetadata([baseColumn({ name: 'title' })]))
+
+    expect(result).toContain('`json:"title"`')
+  })
+})


### PR DESCRIPTION
Closes #1125.

The Go generator writes struct tags as a raw string literal, ```go
`json:"NAME"`
```
and Go raw literals cannot contain a backtick at all. A column named `bad`tag` therefore closes the literal early and the generated file is not parseable Go, so `gofmt` reports "string literal not terminated".

Go allows a struct tag to be an interpreted literal too, so this switches to that form only when the tag contains a backtick, escaping backslashes and double quotes. Names without a backtick keep the exact raw-literal output they had before, which is what the issue asks for.

There were two identical call sites, one for tables and views and one for composite types. Both now go through the same helper.

Three tests added to the existing `test/server/templates/go.test.ts`, which is a pure unit test file needing no database: a backtick name produces the escaped interpreted literal, a name with a double quote and a backtick escapes both, and an ordinary name still produces the unchanged raw literal. The first two fail without the change and the third passes either way, so the previous output is pinned as well.

`prettier --check` and `tsc -p tsconfig.json --noEmit` are clean.
