### PR TITLE
fix: scope pg_indexes join by schemaname

### DIFF
--- a/src/lib/sql/indexes.sql.ts
+++ b/src/lib/sql/indexes.sql.ts
@@ -40,7 +40,7 @@ SELECT
     JOIN pg_namespace n ON c.relnamespace = n.oid
     JOIN pg_am am ON c.relam = am.oid
     JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(idx.indkey)
-    JOIN pg_indexes ix ON c.relname = ix.indexname
+    JOIN pg_indexes ix ON c.relname = ix.indexname AND n.nspname = ix.schemaname
   WHERE
     ${props.schemaFilter ? `n.nspname ${props.schemaFilter}` : 'true'}
     ${props.idsFilter ? `AND idx.indexrelid ${props.idsFilter}` : ''}

--- a/test/server/indexes.ts
+++ b/test/server/indexes.ts
@@ -56,6 +56,52 @@ test('list indexes', async () => {
   )
 })
 
+test('index_definition is scoped to the index schema', async () => {
+  let res = await app.inject({
+    method: 'POST',
+    path: '/query',
+    payload: {
+      query: `
+        drop schema if exists private cascade;
+        drop table if exists public.dup_idx cascade;
+        create schema private;
+        create table public.dup_idx (id int primary key);
+        create table private.dup_idx (id int primary key);
+      `,
+    },
+  })
+  if (res.json().error) {
+    throw new Error(res.payload)
+  }
+
+  res = await app.inject({ method: 'GET', path: '/indexes' })
+  const indexes = res.json<PostgresIndex[]>()
+  const privatePkeys = indexes.filter(
+    ({ schema, index_definition }) =>
+      schema === 'private' && index_definition.includes('dup_idx_pkey')
+  )
+
+  expect(privatePkeys).toHaveLength(1)
+  expect(privatePkeys[0].index_definition).toBe(
+    'CREATE UNIQUE INDEX dup_idx_pkey ON private.dup_idx USING btree (id)'
+  )
+  expect(privatePkeys[0].index_definition).not.toContain('public.dup_idx')
+
+  res = await app.inject({ method: 'GET', path: `/indexes/${privatePkeys[0].id}` })
+  expect(res.json<PostgresIndex>().index_definition).toBe(privatePkeys[0].index_definition)
+
+  res = await app.inject({
+    method: 'POST',
+    path: '/query',
+    payload: {
+      query: `drop schema private cascade; drop table public.dup_idx cascade;`,
+    },
+  })
+  if (res.json().error) {
+    throw new Error(res.payload)
+  }
+})
+
 test('retrieve index', async () => {
   const res = await app.inject({ method: 'GET', path: '/indexes/16400' })
   const index = res.json<PostgresIndex>()


### PR DESCRIPTION
## Summary

- Join `pg_indexes` on both index name **and** `schemaname`, so each index OID maps to exactly one `index_definition`
- Fixes silent duplicates / wrong DDL when multiple schemas share primary-key or index names (e.g. `users_pkey`)

Closes #1136

Independent of #1108 / #1109 (attribute/`indkey` matching).

## Test plan

- [x] Regression: two schemas with identically named `dup_idx_pkey` → one private row whose definition references `private.dup_idx`, not `public.dup_idx`
- [x] Existing `list indexes` / `retrieve index` tests still pass