### PR TITLE
fix: preserve equals signs in function config_params

### DIFF
--- a/src/lib/sql/functions.sql.ts
+++ b/src/lib/sql/functions.sql.ts
@@ -110,10 +110,13 @@ from
       (
         select
           oid,
-          (string_to_array(unnest(proconfig), '='))[1] as param,
-          (string_to_array(unnest(proconfig), '='))[2] as value
+          split_part(cfg, '=', 1) as param,
+          -- Keep everything after the first '=', so values like application_name=api=worker
+          -- round-trip intact (string_to_array(...)[2] truncates at the next '=').
+          substring(cfg from position('=' in cfg) + 1) as value
         from
-          functions
+          functions,
+          lateral unnest(proconfig) as cfg
       ) as t
     group by
       oid

--- a/test/lib/functions.ts
+++ b/test/lib/functions.ts
@@ -531,3 +531,23 @@ test('retrieve function by args filter - function with no arguments', async () =
   })
   expect(res.error).toBeNull()
 })
+
+test('config_params preserves equals signs in values', async () => {
+  await pgMeta.query(`
+    create or replace function public.config_equals_test()
+    returns void
+    language sql
+    set application_name to 'api=worker'
+    as $$ select 1; $$;
+  `)
+
+  const res = await pgMeta.functions.retrieve({
+    schema: 'public',
+    name: 'config_equals_test',
+    args: [],
+  })
+  expect(res.error).toBeNull()
+  expect(res.data?.config_params).toEqual({ application_name: 'api=worker' })
+
+  await pgMeta.query(`drop function public.config_equals_test();`)
+})


### PR DESCRIPTION
## Summary

- Parse `proconfig` by splitting on the **first** `=` only (`split_part` + `substring` via `lateral unnest`)
- Values like `application_name=api=worker` no longer truncate to `api`

Closes #1137

Same class of bug as role config (#1117), but in the functions catalog SQL used by Studio list/retrieve/update.

## Test plan

- [x] Regression: function with `SET application_name TO 'api=worker'` → `config_params.application_name === 'api=worker'`
- [x] Confirmed pre-fix SQL returned `api`