### PR TITLE
fix: quote check constraint names when dropping via column update

### DIFF
--- a/src/lib/PostgresMetaColumns.ts
+++ b/src/lib/PostgresMetaColumns.ts
@@ -332,7 +332,7 @@ BEGIN
   IF v_conname IS NOT NULL THEN
     EXECUTE format('ALTER TABLE ${ident(old!.schema)}.${ident(
       old!.table
-    )} DROP CONSTRAINT %s', v_conname);
+    )} DROP CONSTRAINT %I', v_conname);
   END IF;
 
   ${

--- a/test/lib/columns.ts
+++ b/test/lib/columns.ts
@@ -981,6 +981,27 @@ test('dropping column checks', async () => {
   await pgMeta.query(`drop table t`)
 })
 
+test('dropping hyphenated column check constraints', async () => {
+  await pgMeta.query(`
+    create table public.t (c int8);
+    alter table public.t add constraint "t-c-check" check (c <> 0);
+  `)
+
+  let res = await pgMeta.columns.retrieve({
+    schema: 'public',
+    table: 't',
+    name: 'c',
+  })
+  expect(res.error).toBeNull()
+  expect(res.data?.check).toBeTruthy()
+
+  res = await pgMeta.columns.update(res.data!.id, { check: null })
+  expect(res.error).toBeNull()
+  expect(res.data?.check).toBeNull()
+
+  await pgMeta.query(`drop table public.t`)
+})
+
 test('column with fully-qualified type', async () => {
   await pgMeta.query(`create table public.t(); create schema s; create type s.my_type as enum ();`)
 


### PR DESCRIPTION
## Summary

- Fixes #1140: clearing/changing a column check via `columns.update` used `DROP CONSTRAINT %s`, which breaks for hyphenated or otherwise non-plain constraint names (e.g. `"t-c-check"`).
- Switch to `%I` so names are identifier-quoted, consistent with unique-constraint drops in the same path.
- Adds a regression test that creates a hyphenated check and clears it through the columns API.

## Test plan

- [x] `npx vitest run test/index.test.ts -t "dropping hyphenated column check|dropping column checks"`
- [ ] Confirm Studio / Management API can clear a check whose constraint name contains a hyphen