### PR TITLE
fix: quote function config_params values in CREATE FUNCTION SET

### DIFF
--- a/src/lib/PostgresMetaFunctions.ts
+++ b/src/lib/PostgresMetaFunctions.ts
@@ -4,6 +4,15 @@ import { filterByList, filterByValue } from './helpers.js'
 import { PostgresMetaResult, PostgresFunction, PostgresFunctionCreate } from './types.js'
 import { FUNCTIONS_SQL } from './sql/functions.sql.js'
 
+// GUC_LIST_INPUT parameters (e.g. search_path) expect a comma-separated list of
+// individually-quoted values. Scalar GUCs (e.g. statement_timeout = 5s) must be
+// a single quoted literal — unquoted `TO 5s` is a syntax error.
+const literalConfigValue = (value: string): string =>
+  value
+    .split(',')
+    .map((part) => literal(part.trim()))
+    .join(', ')
+
 export default class PostgresMetaFunctions {
   query: (sql: string) => Promise<PostgresMetaResult<any>>
 
@@ -252,9 +261,10 @@ export default class PostgresMetaFunctions {
       ${
         config_params
           ? Object.entries(config_params)
-              .map(
-                ([param, value]: string[]) =>
-                  `SET ${param} ${value[0] === 'FROM CURRENT' ? 'FROM CURRENT' : 'TO ' + value}`
+              .map(([param, value]: string[]) =>
+                value === 'FROM CURRENT'
+                  ? `SET ${ident(param)} FROM CURRENT`
+                  : `SET ${ident(param)} TO ${literalConfigValue(value)}`
               )
               .join('\n')
           : ''

--- a/test/lib/functions.ts
+++ b/test/lib/functions.ts
@@ -531,3 +531,23 @@ test('retrieve function by args filter - function with no arguments', async () =
   })
   expect(res.error).toBeNull()
 })
+
+test('create function with statement_timeout config_params', async () => {
+  // Unquoted `SET statement_timeout TO 5s` is invalid SQL; values must be literals.
+  const res = await pgMeta.functions.create({
+    name: 'test_timeout_func',
+    schema: 'public',
+    args: [],
+    definition: 'select 1',
+    return_type: 'integer',
+    language: 'sql',
+    behavior: 'VOLATILE',
+    security_definer: false,
+    config_params: { statement_timeout: '5s' },
+  })
+  expect(res.error).toBeNull()
+  expect(res.data?.config_params).toMatchObject({ statement_timeout: '5s' })
+  expect(res.data?.complete_statement).toContain(`SET statement_timeout TO '5s'`)
+
+  await pgMeta.functions.remove(res.data!.id)
+})


### PR DESCRIPTION
## Summary

- Fixes https://github.com/supabase/postgres-meta/issues/1142: `SET statement_timeout TO 5s` (and similar) from `functions.create` / regenerate-on-update is invalid SQL.
- Quote GUC values with `literal()`, split list GUCs like `search_path` into individually quoted items, and `ident()` the parameter name — aligned with role config quoting.
- Also fixes the broken `FROM CURRENT` check (`value[0] === 'FROM CURRENT'` compared the first character, so it never matched).

## Test plan

- [x] `npx vitest run test/index.test.ts -t "create function with statement_timeout|retrieve, create, update, delete"`
- [ ] Studio: create a function with `statement_timeout = 5s` config